### PR TITLE
feat: add release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to publish, for example v0.1.0"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish npm package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve ref
+        id: ref
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=refs/tags/${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_REF}" >> "$GITHUB_OUTPUT"
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.value }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Update npm
+        run: npm install -g npm@^11.15.0
+
+      - name: Validate tag matches package version
+        shell: bash
+        run: |
+          VERSION="v$(jq -r '.version' package.json)"
+          TAG="${{ steps.ref.outputs.tag }}"
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "Tag $TAG does not match package version $VERSION"
+            exit 1
+          fi
+
+      - name: Install
+        run: npm ci
+
+      - name: Check
+        run: npm run check
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish
+
+      - name: Ensure GitHub release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          TAG="${{ steps.ref.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists"
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          fi

--- a/package.json
+++ b/package.json
@@ -11,6 +11,18 @@
     "README.md",
     "package.json"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/amanharshx/ultralytics-mcp.git"
+  },
+  "homepage": "https://github.com/amanharshx/ultralytics-mcp#readme",
+  "bugs": {
+    "url": "https://github.com/amanharshx/ultralytics-mcp/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Summary
Add release automation for npm and GitHub releases using trusted publishing.

## Motivation
The package is already tagged and released on GitHub, but npm publishing is not wired up yet. This adds the missing automation so future releases can ship to both places cleanly.

## Key Changes
- add tag-driven release workflow with manual dispatch support for existing tags
- add publish metadata in `package.json` for public npm publishing and provenance
- validate tag/version match before publishing