### PR TITLE
feat: add projects create tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,28 @@
 # Ultralytics Platform MCP
 
-MCP server for the Ultralytics Platform REST API.
+MCP server for the [Ultralytics Platform](https://platform.ultralytics.com).
 
-Current milestone: protocol scaffold with CLI entrypoint and protocol-level
-tests. Tooling and API features land incrementally from here.
+> Independent community project. Not affiliated with or endorsed by Ultralytics.
+
+Current milestone: read, monitor, predict, export, and project creation tools
+are available. Additional resource-management tools land incrementally from
+here.
+
+## Tools (15)
+
+| Tool | Description |
+| --- | --- |
+| `projects_list` / `projects_get` | Browse projects |
+| `projects_create` | Create projects |
+| `datasets_list` / `datasets_get` | Browse datasets |
+| `models_list` / `models_get` | Browse trained models and metrics |
+| `training_monitor` | Status, progress, and latest metrics |
+| `model_predict` | Run inference on an image URL or base64 source |
+| `model_download` | Download a model weight file to a local path |
+| `gpu_availability` | Cloud GPU stock status |
+| `exports_list` / `export_status` | List / check export jobs |
+| `export_create` | Create an export job — **requires `confirm_cost: true`** |
+| `training_start` | Start cloud training — **requires `confirm_cost: true`** |
 
 ## Development
 

--- a/fixtures/parity/projects_create.json
+++ b/fixtures/parity/projects_create.json
@@ -1,0 +1,37 @@
+{
+  "tool": "projects_create",
+  "args": {
+    "name": "Road Safety",
+    "slug": "road",
+    "description": "Detection experiments"
+  },
+  "api": [
+    {
+      "method": "POST",
+      "path": "/api/projects",
+      "json": {
+        "name": "Road Safety",
+        "slug": "road",
+        "description": "Detection experiments"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "project": {
+            "_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "Road Safety",
+            "slug": "road"
+          }
+        }
+      }
+    }
+  ],
+  "expected": {
+    "summary": "Created project aaaaaaaaaaaaaaaaaaaaaaaa slug=road.",
+    "data": {
+      "_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+      "name": "Road Safety",
+      "slug": "road"
+    }
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -17,7 +17,7 @@ import { exportCreate, exportStatus, exportsList } from "./exports.js";
 import { gpuAvailability } from "./gpu.js";
 import { modelsGet, modelsList } from "./models.js";
 import { modelPredict } from "./predict.js";
-import { projectsGet, projectsList } from "./projects.js";
+import { projectsCreate, projectsGet, projectsList } from "./projects.js";
 import { trainingMonitor, trainingStart } from "./training.js";
 
 export { datasetsGet, datasetsList } from "./datasets.js";
@@ -26,13 +26,14 @@ export { exportCreate, exportStatus, exportsList } from "./exports.js";
 export { gpuAvailability } from "./gpu.js";
 export { modelsGet, modelsList } from "./models.js";
 export { modelPredict } from "./predict.js";
-export { projectsGet, projectsList } from "./projects.js";
+export { projectsCreate, projectsGet, projectsList } from "./projects.js";
 export { trainingMonitor, trainingStart } from "./training.js";
 
 /** Names of the read-only tools registered by `registerReadTools`. */
 export const READ_TOOL_NAMES = [
   "projects_list",
   "projects_get",
+  "projects_create",
   "datasets_list",
   "datasets_get",
   "models_list",
@@ -65,6 +66,22 @@ export function registerReadTools(
     },
     async ({ project }) =>
       toMcpTextResult(await projectsGet(getClient(), project)),
+  );
+
+  server.registerTool(
+    "projects_create",
+    {
+      description: "Create a project in your Ultralytics workspace.",
+      inputSchema: {
+        name: z.string(),
+        slug: z.string().optional(),
+        description: z.string().optional(),
+      },
+    },
+    async ({ name, slug, description }) =>
+      toMcpTextResult(
+        await projectsCreate(getClient(), { name, slug, description }),
+      ),
   );
 
   server.registerTool(

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -5,6 +5,11 @@ import { resolveProject } from "../resolve.js";
 import type { NormalizedToolResult } from "../tool-result.js";
 import { asRecord, listField, pyCount, pyField } from "./shared.js";
 
+function resourceId(item: Record<string, unknown>, fallback?: string): string {
+  const value = item._id ?? item.id ?? item.projectId ?? item.datasetId;
+  return String(value ?? fallback ?? "None");
+}
+
 /** List projects in the workspace, optionally filtered by username. */
 export async function projectsList(
   client: UltralyticsClient,
@@ -39,6 +44,36 @@ export async function projectsGet(
     summary:
       `Project '${pyField(fields.name)}' (${pyField(fields.visibility)}), ` +
       `${pyCount(fields, "modelCount")} model(s).`,
+    data: item,
+  };
+}
+
+export interface ProjectsCreateOptions {
+  name: string;
+  slug?: string;
+  description?: string;
+}
+
+/** Create a project. */
+export async function projectsCreate(
+  client: UltralyticsClient,
+  options: ProjectsCreateOptions,
+): Promise<NormalizedToolResult> {
+  const payload: Record<string, unknown> = { name: options.name };
+  if (options.slug !== undefined) {
+    payload.slug = options.slug;
+  }
+  if (options.description !== undefined) {
+    payload.description = options.description;
+  }
+
+  const data = await client.postJson("/projects", payload);
+  const record = asRecord(data);
+  const item = asRecord("project" in record ? record.project : data);
+  const id = resourceId(item);
+  const slug = item.slug ?? options.slug ?? "None";
+  return {
+    summary: `Created project ${id} slug=${String(slug)}.`,
     data: item,
   };
 }

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -12,6 +12,7 @@ import type { NormalizedToolResult } from "../src/tool-result.js";
 import {
   modelDownload,
   modelsGet,
+  projectsCreate,
   projectsList,
   trainingMonitor,
 } from "../src/tools/index.js";
@@ -108,6 +109,12 @@ const TOOL_RUNNERS: Record<
 > = {
   projects_list: (client, args) =>
     projectsList(client, args.username as string | undefined),
+  projects_create: (client, args) =>
+    projectsCreate(client, {
+      name: args.name as string,
+      slug: args.slug as string | undefined,
+      description: args.description as string | undefined,
+    }),
   models_get: (client, args) =>
     modelsGet(client, args.model as string, args.project as string | undefined),
   training_monitor: (client, args) =>
@@ -148,6 +155,7 @@ describe("parity fixtures", () => {
       [
         "model_download_signed_url.json",
         "models_get.json",
+        "projects_create.json",
         "projects_list.json",
         "training_monitor_private.json",
       ].sort(),

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -40,4 +40,7 @@ test("server registers all available tools over the protocol", async () => {
   const projectsGet = tools.find((tool) => tool.name === "projects_get");
   expect(projectsGet?.inputSchema?.type).toBe("object");
   expect(projectsGet?.inputSchema?.required).toEqual(["project"]);
+
+  const projectsCreate = tools.find((tool) => tool.name === "projects_create");
+  expect(projectsCreate?.inputSchema?.required).toEqual(["name"]);
 });

--- a/tests/tools/projects.test.ts
+++ b/tests/tools/projects.test.ts
@@ -1,7 +1,36 @@
 import { describe, expect, test } from "vitest";
 
-import { projectsGet, projectsList } from "../../src/tools/projects.js";
-import { jsonResponse, routeClient } from "../helpers.js";
+import { UltralyticsClient } from "../../src/client.js";
+import {
+  projectsCreate,
+  projectsGet,
+  projectsList,
+} from "../../src/tools/projects.js";
+import { BASE, jsonResponse, KEY, routeClient } from "../helpers.js";
+
+function captureClient(responder: (url: string) => Response) {
+  const calls: { url: string; method: string; body: unknown }[] = [];
+  const impl = (async (url: string | URL, init: RequestInit = {}) => {
+    let body: unknown;
+    if (typeof init.body === "string") {
+      body = JSON.parse(init.body);
+    }
+    calls.push({
+      url: String(url),
+      method: (init.method ?? "GET").toUpperCase(),
+      body,
+    });
+    return responder(String(url));
+  }) as unknown as typeof fetch;
+  return {
+    client: new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: impl,
+    }),
+    calls,
+  };
+}
 
 describe("projectsList", () => {
   test("normalizes items and drops unknown fields", async () => {
@@ -92,5 +121,30 @@ describe("projectsGet", () => {
     );
     const result = await projectsGet(client, id);
     expect(result.summary).toBe("Project 'None' (None), ? model(s).");
+  });
+});
+
+describe("projectsCreate", () => {
+  test("posts the project payload and summarizes created project", async () => {
+    const { client, calls } = captureClient(() =>
+      jsonResponse({
+        project: { _id: "p".repeat(24), slug: "road", name: "Road Safety" },
+      }),
+    );
+    const result = await projectsCreate(client, {
+      name: "Road Safety",
+      slug: "road",
+      description: "Detection experiments",
+    });
+    expect(calls[0]).toEqual({
+      url: `${BASE}/projects`,
+      method: "POST",
+      body: {
+        name: "Road Safety",
+        slug: "road",
+        description: "Detection experiments",
+      },
+    });
+    expect(result.summary).toBe(`Created project ${"p".repeat(24)} slug=road.`);
   });
 });


### PR DESCRIPTION
## Summary
Add the `projects_create` MCP tool for creating projects in the Ultralytics workspace.

## Motivation
This adds the first project-management write tool while keeping the scope small and easy to review.

## Key Changes
- add `projects_create` tool implementation and MCP registration
- add focused tests and parity fixture coverage for project creation
- update README tool list to reflect the new capability