### PR TITLE
feat: add projects delete tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ MCP server for the [Ultralytics Platform](https://platform.ultralytics.com).
 
 > Independent community project. Not affiliated with or endorsed by Ultralytics.
 
-Current milestone: read, monitor, predict, export, and project creation tools
-are available. Additional resource-management tools land incrementally from
-here.
+Current milestone: read, monitor, predict, export, and initial project
+lifecycle tools are available. Additional resource-management tools land
+incrementally from here.
 
-## Tools (15)
+## Tools (16)
 
 | Tool | Description |
 | --- | --- |
 | `projects_list` / `projects_get` | Browse projects |
-| `projects_create` | Create projects |
+| `projects_create` / `projects_delete` | Create / soft-delete projects |
 | `datasets_list` / `datasets_get` | Browse datasets |
 | `models_list` / `models_get` | Browse trained models and metrics |
 | `training_monitor` | Status, progress, and latest metrics |

--- a/fixtures/parity/projects_delete.json
+++ b/fixtures/parity/projects_delete.json
@@ -1,0 +1,46 @@
+{
+  "tool": "projects_delete",
+  "args": {
+    "project": "user/road"
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/projects",
+      "query": {
+        "username": "user"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "projects": [
+            {
+              "_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+              "slug": "road",
+              "username": "user"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/projects/aaaaaaaaaaaaaaaaaaaaaaaa",
+      "response": {
+        "status": 200,
+        "json": {
+          "deleted": true
+        }
+      }
+    }
+  ],
+  "expected": {
+    "summary": "Deleted project aaaaaaaaaaaaaaaaaaaaaaaa (soft delete).",
+    "data": {
+      "id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+      "response": {
+        "deleted": true
+      }
+    }
+  }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -106,6 +106,11 @@ export class UltralyticsClient {
     });
   }
 
+  /** DELETE requests are state-changing and do not retry 429 responses. */
+  async delete(path: string): Promise<unknown> {
+    return this.request("DELETE", path, { retryOn429: false });
+  }
+
   /** Download bytes from a signed URL WITHOUT forwarding API credentials. */
   async downloadBytes(url: string): Promise<Uint8Array> {
     let attempt = 0;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -17,7 +17,12 @@ import { exportCreate, exportStatus, exportsList } from "./exports.js";
 import { gpuAvailability } from "./gpu.js";
 import { modelsGet, modelsList } from "./models.js";
 import { modelPredict } from "./predict.js";
-import { projectsCreate, projectsGet, projectsList } from "./projects.js";
+import {
+  projectsCreate,
+  projectsDelete,
+  projectsGet,
+  projectsList,
+} from "./projects.js";
 import { trainingMonitor, trainingStart } from "./training.js";
 
 export { datasetsGet, datasetsList } from "./datasets.js";
@@ -26,7 +31,12 @@ export { exportCreate, exportStatus, exportsList } from "./exports.js";
 export { gpuAvailability } from "./gpu.js";
 export { modelsGet, modelsList } from "./models.js";
 export { modelPredict } from "./predict.js";
-export { projectsCreate, projectsGet, projectsList } from "./projects.js";
+export {
+  projectsCreate,
+  projectsDelete,
+  projectsGet,
+  projectsList,
+} from "./projects.js";
 export { trainingMonitor, trainingStart } from "./training.js";
 
 /** Names of the read-only tools registered by `registerReadTools`. */
@@ -34,6 +44,7 @@ export const READ_TOOL_NAMES = [
   "projects_list",
   "projects_get",
   "projects_create",
+  "projects_delete",
   "datasets_list",
   "datasets_get",
   "models_list",
@@ -82,6 +93,17 @@ export function registerReadTools(
       toMcpTextResult(
         await projectsCreate(getClient(), { name, slug, description }),
       ),
+  );
+
+  server.registerTool(
+    "projects_delete",
+    {
+      description:
+        "Soft-delete a project by id, slug, username/slug, or project ul:// URI.",
+      inputSchema: { project: z.string() },
+    },
+    async ({ project }) =>
+      toMcpTextResult(await projectsDelete(getClient(), project)),
   );
 
   server.registerTool(

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -77,3 +77,16 @@ export async function projectsCreate(
     data: item,
   };
 }
+
+/** Soft-delete a project by id, slug, username/slug, or project ul:// URI. */
+export async function projectsDelete(
+  client: UltralyticsClient,
+  project: string,
+): Promise<NormalizedToolResult> {
+  const projectId = await resolveProject(client, project);
+  const data = await client.delete(`/projects/${projectId}`);
+  return {
+    summary: `Deleted project ${projectId} (soft delete).`,
+    data: { id: projectId, response: data },
+  };
+}

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -13,6 +13,7 @@ import {
   modelDownload,
   modelsGet,
   projectsCreate,
+  projectsDelete,
   projectsList,
   trainingMonitor,
 } from "../src/tools/index.js";
@@ -115,6 +116,8 @@ const TOOL_RUNNERS: Record<
       slug: args.slug as string | undefined,
       description: args.description as string | undefined,
     }),
+  projects_delete: (client, args) =>
+    projectsDelete(client, args.project as string),
   models_get: (client, args) =>
     modelsGet(client, args.model as string, args.project as string | undefined),
   training_monitor: (client, args) =>
@@ -156,6 +159,7 @@ describe("parity fixtures", () => {
         "model_download_signed_url.json",
         "models_get.json",
         "projects_create.json",
+        "projects_delete.json",
         "projects_list.json",
         "training_monitor_private.json",
       ].sort(),

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -43,4 +43,7 @@ test("server registers all available tools over the protocol", async () => {
 
   const projectsCreate = tools.find((tool) => tool.name === "projects_create");
   expect(projectsCreate?.inputSchema?.required).toEqual(["name"]);
+
+  const projectsDelete = tools.find((tool) => tool.name === "projects_delete");
+  expect(projectsDelete?.inputSchema?.required).toEqual(["project"]);
 });

--- a/tests/tools/projects.test.ts
+++ b/tests/tools/projects.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import { UltralyticsClient } from "../../src/client.js";
 import {
   projectsCreate,
+  projectsDelete,
   projectsGet,
   projectsList,
 } from "../../src/tools/projects.js";
@@ -146,5 +147,27 @@ describe("projectsCreate", () => {
       },
     });
     expect(result.summary).toBe(`Created project ${"p".repeat(24)} slug=road.`);
+  });
+});
+
+describe("projectsDelete", () => {
+  test("resolves a reference and deletes the project", async () => {
+    const { client, calls } = captureClient((url) => {
+      const parsed = new URL(url);
+      if (parsed.pathname === "/api/projects") {
+        return jsonResponse({
+          projects: [{ _id: "p".repeat(24), slug: "road", username: "user" }],
+        });
+      }
+      return jsonResponse({ deleted: true });
+    });
+    const result = await projectsDelete(client, "user/road");
+    expect(calls.at(-1)).toMatchObject({
+      url: `${BASE}/projects/${"p".repeat(24)}`,
+      method: "DELETE",
+    });
+    expect(result.summary).toBe(
+      `Deleted project ${"p".repeat(24)} (soft delete).`,
+    );
   });
 });


### PR DESCRIPTION
## Summary
Add MCP support for soft-deleting projects from Ultralytics Platform.

## Motivation
This rounds out another core project-management operation while keeping the write-tool rollout small and easy to review.

## Key Changes
- add `projects_delete` tool wiring and project delete helper
- add client `DELETE` support for non-retrying state-changing requests
- add tests, parity fixture, and README sync for `projects_delete`