### PR TITLE
feat: add datasets create tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ MCP server for the [Ultralytics Platform](https://platform.ultralytics.com).
 
 > Independent community project. Not affiliated with or endorsed by Ultralytics.
 
-Current milestone: read, monitor, predict, export, and initial project
-lifecycle tools are available. Additional resource-management tools land
-incrementally from here.
+Current milestone: read, monitor, predict, export, and initial project and
+dataset lifecycle tools are available. Additional resource-management tools
+land incrementally from here.
 
-## Tools (16)
+## Tools (17)
 
 | Tool | Description |
 | --- | --- |
 | `projects_list` / `projects_get` | Browse projects |
 | `projects_create` / `projects_delete` | Create / soft-delete projects |
-| `datasets_list` / `datasets_get` | Browse datasets |
+| `datasets_list` / `datasets_get` / `datasets_create` | Browse / create datasets |
 | `models_list` / `models_get` | Browse trained models and metrics |
 | `training_monitor` | Status, progress, and latest metrics |
 | `model_predict` | Run inference on an image URL or base64 source |

--- a/fixtures/parity/datasets_create.json
+++ b/fixtures/parity/datasets_create.json
@@ -1,0 +1,41 @@
+{
+  "tool": "datasets_create",
+  "args": {
+    "name": "Dataset",
+    "task": "detect",
+    "slug": "data",
+    "visibility": "private",
+    "classNames": ["car", "person"]
+  },
+  "api": [
+    {
+      "method": "POST",
+      "path": "/api/datasets",
+      "json": {
+        "name": "Dataset",
+        "task": "detect",
+        "slug": "data",
+        "visibility": "private",
+        "classNames": ["car", "person"]
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "dataset": {
+            "_id": "dddddddddddddddddddddddd",
+            "slug": "data",
+            "task": "detect"
+          }
+        }
+      }
+    }
+  ],
+  "expected": {
+    "summary": "Created dataset dddddddddddddddddddddddd slug=data task=detect.",
+    "data": {
+      "_id": "dddddddddddddddddddddddd",
+      "slug": "data",
+      "task": "detect"
+    }
+  }
+}

--- a/src/tools/datasets.ts
+++ b/src/tools/datasets.ts
@@ -5,6 +5,20 @@ import { resolveDataset } from "../resolve.js";
 import type { NormalizedToolResult } from "../tool-result.js";
 import { asRecord, listField, pyCount, pyField } from "./shared.js";
 
+const DATASET_TASKS = new Set([
+  "detect",
+  "segment",
+  "semantic",
+  "classify",
+  "pose",
+  "obb",
+]);
+
+function resourceId(item: Record<string, unknown>, fallback?: string): string {
+  const value = item._id ?? item.id ?? item.projectId ?? item.datasetId;
+  return String(value ?? fallback ?? "None");
+}
+
 /** List datasets in the workspace, optionally filtered by username. */
 export async function datasetsList(
   client: UltralyticsClient,
@@ -40,6 +54,57 @@ export async function datasetsGet(
     summary:
       `Dataset '${pyField(fields.name)}' [${pyField(fields.task)}], ` +
       `${pyCount(fields, "imageCount")} images, ${pyCount(fields, "classCount")} classes.`,
+    data: item,
+  };
+}
+
+export interface DatasetsCreateOptions {
+  name: string;
+  task: string;
+  slug: string;
+  description?: string;
+  visibility?: string;
+  classNames?: string[];
+}
+
+/** Create a dataset. */
+export async function datasetsCreate(
+  client: UltralyticsClient,
+  options: DatasetsCreateOptions,
+): Promise<NormalizedToolResult> {
+  if (!DATASET_TASKS.has(options.task)) {
+    const allowed = Array.from(DATASET_TASKS).sort().join(", ");
+    throw new Error(
+      `Unsupported dataset task '${options.task}'. Expected one of: ${allowed}.`,
+    );
+  }
+  if (!options.slug.trim()) {
+    throw new Error("`slug` is required.");
+  }
+
+  const payload: Record<string, unknown> = {
+    name: options.name,
+    task: options.task,
+    slug: options.slug,
+  };
+  if (options.description !== undefined) {
+    payload.description = options.description;
+  }
+  if (options.visibility !== undefined) {
+    payload.visibility = options.visibility;
+  }
+  if (options.classNames !== undefined) {
+    payload.classNames = options.classNames;
+  }
+
+  const data = await client.postJson("/datasets", payload);
+  const record = asRecord(data);
+  const item = asRecord("dataset" in record ? record.dataset : data);
+  const id = resourceId(item);
+  const slug = item.slug ?? options.slug;
+  const task = item.task ?? options.task;
+  return {
+    summary: `Created dataset ${id} slug=${String(slug)} task=${String(task)}.`,
     data: item,
   };
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 import type { UltralyticsClient } from "../client.js";
 import { toMcpTextResult } from "../tool-result.js";
-import { datasetsGet, datasetsList } from "./datasets.js";
+import { datasetsCreate, datasetsGet, datasetsList } from "./datasets.js";
 import { modelDownload } from "./downloads.js";
 import { exportCreate, exportStatus, exportsList } from "./exports.js";
 import { gpuAvailability } from "./gpu.js";
@@ -25,7 +25,7 @@ import {
 } from "./projects.js";
 import { trainingMonitor, trainingStart } from "./training.js";
 
-export { datasetsGet, datasetsList } from "./datasets.js";
+export { datasetsCreate, datasetsGet, datasetsList } from "./datasets.js";
 export { modelDownload } from "./downloads.js";
 export { exportCreate, exportStatus, exportsList } from "./exports.js";
 export { gpuAvailability } from "./gpu.js";
@@ -47,6 +47,7 @@ export const READ_TOOL_NAMES = [
   "projects_delete",
   "datasets_list",
   "datasets_get",
+  "datasets_create",
   "models_list",
   "models_get",
   "gpu_availability",
@@ -125,6 +126,32 @@ export function registerReadTools(
     },
     async ({ dataset }) =>
       toMcpTextResult(await datasetsGet(getClient(), dataset)),
+  );
+
+  server.registerTool(
+    "datasets_create",
+    {
+      description: "Create a dataset in your Ultralytics workspace.",
+      inputSchema: {
+        name: z.string(),
+        task: z.string(),
+        slug: z.string(),
+        description: z.string().optional(),
+        visibility: z.string().optional(),
+        classNames: z.array(z.string()).optional(),
+      },
+    },
+    async ({ name, task, slug, description, visibility, classNames }) =>
+      toMcpTextResult(
+        await datasetsCreate(getClient(), {
+          name,
+          task,
+          slug,
+          description,
+          visibility,
+          classNames,
+        }),
+      ),
   );
 
   server.registerTool(

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { UltralyticsClient } from "../src/client.js";
 import type { NormalizedToolResult } from "../src/tool-result.js";
 import {
+  datasetsCreate,
   modelDownload,
   modelsGet,
   projectsCreate,
@@ -28,6 +29,7 @@ const apiStepSchema = z.object({
   method: z.string(),
   path: z.string(),
   query: z.record(z.string(), z.string()).optional(),
+  json: z.unknown().optional(),
   response: responseSchema,
 });
 
@@ -83,6 +85,9 @@ function replayFetch(steps: Fixture["api"]): typeof fetch {
         }
       }
       if (!queryMatches) continue;
+      if (step.json !== undefined) {
+        expect(JSON.parse(String(init.body))).toEqual(step.json);
+      }
 
       entry.used = true;
       const body =
@@ -115,6 +120,15 @@ const TOOL_RUNNERS: Record<
       name: args.name as string,
       slug: args.slug as string | undefined,
       description: args.description as string | undefined,
+    }),
+  datasets_create: (client, args) =>
+    datasetsCreate(client, {
+      name: args.name as string,
+      task: args.task as string,
+      slug: args.slug as string,
+      description: args.description as string | undefined,
+      visibility: args.visibility as string | undefined,
+      classNames: args.classNames as string[] | undefined,
     }),
   projects_delete: (client, args) =>
     projectsDelete(client, args.project as string),
@@ -157,6 +171,7 @@ describe("parity fixtures", () => {
     expect([...fixtureFiles].sort()).toEqual(
       [
         "model_download_signed_url.json",
+        "datasets_create.json",
         "models_get.json",
         "projects_create.json",
         "projects_delete.json",

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -46,4 +46,11 @@ test("server registers all available tools over the protocol", async () => {
 
   const projectsDelete = tools.find((tool) => tool.name === "projects_delete");
   expect(projectsDelete?.inputSchema?.required).toEqual(["project"]);
+
+  const datasetsCreate = tools.find((tool) => tool.name === "datasets_create");
+  expect(datasetsCreate?.inputSchema?.required).toEqual([
+    "name",
+    "task",
+    "slug",
+  ]);
 });

--- a/tests/tools/datasets.test.ts
+++ b/tests/tools/datasets.test.ts
@@ -1,7 +1,36 @@
 import { describe, expect, test } from "vitest";
 
-import { datasetsGet, datasetsList } from "../../src/tools/datasets.js";
-import { jsonResponse, routeClient } from "../helpers.js";
+import { UltralyticsClient } from "../../src/client.js";
+import {
+  datasetsCreate,
+  datasetsGet,
+  datasetsList,
+} from "../../src/tools/datasets.js";
+import { BASE, jsonResponse, KEY, routeClient } from "../helpers.js";
+
+function captureClient(responder: (url: string) => Response) {
+  const calls: { url: string; method: string; body: unknown }[] = [];
+  const impl = (async (url: string | URL, init: RequestInit = {}) => {
+    let body: unknown;
+    if (typeof init.body === "string") {
+      body = JSON.parse(init.body);
+    }
+    calls.push({
+      url: String(url),
+      method: (init.method ?? "GET").toUpperCase(),
+      body,
+    });
+    return responder(String(url));
+  }) as unknown as typeof fetch;
+  return {
+    client: new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: impl,
+    }),
+    calls,
+  };
+}
 
 describe("datasetsList", () => {
   test("normalizes items and summarizes count", async () => {
@@ -80,5 +109,47 @@ describe("datasetsGet", () => {
     );
     const result = await datasetsGet(client, id);
     expect(result.summary).toBe("Dataset 'None' [None], ? images, ? classes.");
+  });
+});
+
+describe("datasetsCreate", () => {
+  test("posts the dataset payload and validates task before network", async () => {
+    const { client, calls } = captureClient(() =>
+      jsonResponse({
+        dataset: { _id: "d".repeat(24), slug: "data", task: "detect" },
+      }),
+    );
+    const result = await datasetsCreate(client, {
+      name: "Dataset",
+      task: "detect",
+      slug: "data",
+      visibility: "private",
+      classNames: ["car", "person"],
+    });
+    await expect(
+      datasetsCreate(client, {
+        name: "Bad",
+        task: "bad-task",
+        slug: "bad",
+      }),
+    ).rejects.toThrow(/Unsupported dataset task/);
+    await expect(
+      datasetsCreate(client, { name: "Bad", task: "detect", slug: "" }),
+    ).rejects.toThrow(/`slug` is required/);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      url: `${BASE}/datasets`,
+      method: "POST",
+      body: {
+        name: "Dataset",
+        task: "detect",
+        slug: "data",
+        visibility: "private",
+        classNames: ["car", "person"],
+      },
+    });
+    expect(result.summary).toBe(
+      `Created dataset ${"d".repeat(24)} slug=data task=detect.`,
+    );
   });
 });


### PR DESCRIPTION
## Summary
Add MCP support for creating datasets in Ultralytics Platform.

## Motivation
This adds first dataset-management write operation while keeping scope small and easy to review on its own.

## Key Changes
- add `datasets_create` tool wiring and dataset creation helper
- validate dataset task and required slug before sending network request
- add tests, parity fixture, parity request-body checks, and README sync