### PR TITLE
feat: add datasets delete tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Current milestone: read, monitor, predict, export, and initial project and
 dataset lifecycle tools are available. Additional resource-management tools
 land incrementally from here.
 
-## Tools (17)
+## Tools (18)
 
 | Tool | Description |
 | --- | --- |
 | `projects_list` / `projects_get` | Browse projects |
 | `projects_create` / `projects_delete` | Create / soft-delete projects |
-| `datasets_list` / `datasets_get` / `datasets_create` | Browse / create datasets |
+| `datasets_list` / `datasets_get` / `datasets_create` / `datasets_delete` | Browse / create / soft-delete datasets |
 | `models_list` / `models_get` | Browse trained models and metrics |
 | `training_monitor` | Status, progress, and latest metrics |
 | `model_predict` | Run inference on an image URL or base64 source |

--- a/fixtures/parity/datasets_delete.json
+++ b/fixtures/parity/datasets_delete.json
@@ -1,0 +1,47 @@
+{
+  "tool": "datasets_delete",
+  "args": {
+    "dataset": "user/data"
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/datasets",
+      "query": {
+        "slug": "data",
+        "username": "user"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "datasets": [
+            {
+              "_id": "dddddddddddddddddddddddd",
+              "slug": "data",
+              "username": "user"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/datasets/dddddddddddddddddddddddd",
+      "response": {
+        "status": 200,
+        "json": {
+          "deleted": true
+        }
+      }
+    }
+  ],
+  "expected": {
+    "summary": "Deleted dataset dddddddddddddddddddddddd (soft delete).",
+    "data": {
+      "id": "dddddddddddddddddddddddd",
+      "response": {
+        "deleted": true
+      }
+    }
+  }
+}

--- a/src/tools/datasets.ts
+++ b/src/tools/datasets.ts
@@ -108,3 +108,16 @@ export async function datasetsCreate(
     data: item,
   };
 }
+
+/** Soft-delete a dataset by id, slug, username/slug, or dataset ul:// URI. */
+export async function datasetsDelete(
+  client: UltralyticsClient,
+  dataset: string,
+): Promise<NormalizedToolResult> {
+  const datasetId = await resolveDataset(client, dataset);
+  const data = await client.delete(`/datasets/${datasetId}`);
+  return {
+    summary: `Deleted dataset ${datasetId} (soft delete).`,
+    data: { id: datasetId, response: data },
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,7 +11,12 @@ import { z } from "zod";
 
 import type { UltralyticsClient } from "../client.js";
 import { toMcpTextResult } from "../tool-result.js";
-import { datasetsCreate, datasetsGet, datasetsList } from "./datasets.js";
+import {
+  datasetsCreate,
+  datasetsDelete,
+  datasetsGet,
+  datasetsList,
+} from "./datasets.js";
 import { modelDownload } from "./downloads.js";
 import { exportCreate, exportStatus, exportsList } from "./exports.js";
 import { gpuAvailability } from "./gpu.js";
@@ -25,7 +30,12 @@ import {
 } from "./projects.js";
 import { trainingMonitor, trainingStart } from "./training.js";
 
-export { datasetsCreate, datasetsGet, datasetsList } from "./datasets.js";
+export {
+  datasetsCreate,
+  datasetsDelete,
+  datasetsGet,
+  datasetsList,
+} from "./datasets.js";
 export { modelDownload } from "./downloads.js";
 export { exportCreate, exportStatus, exportsList } from "./exports.js";
 export { gpuAvailability } from "./gpu.js";
@@ -48,6 +58,7 @@ export const READ_TOOL_NAMES = [
   "datasets_list",
   "datasets_get",
   "datasets_create",
+  "datasets_delete",
   "models_list",
   "models_get",
   "gpu_availability",
@@ -152,6 +163,17 @@ export function registerReadTools(
           classNames,
         }),
       ),
+  );
+
+  server.registerTool(
+    "datasets_delete",
+    {
+      description:
+        "Soft-delete a dataset by id, slug, username/slug, or dataset ul:// URI.",
+      inputSchema: { dataset: z.string() },
+    },
+    async ({ dataset }) =>
+      toMcpTextResult(await datasetsDelete(getClient(), dataset)),
   );
 
   server.registerTool(

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -11,6 +11,7 @@ import { UltralyticsClient } from "../src/client.js";
 import type { NormalizedToolResult } from "../src/tool-result.js";
 import {
   datasetsCreate,
+  datasetsDelete,
   modelDownload,
   modelsGet,
   projectsCreate,
@@ -130,6 +131,8 @@ const TOOL_RUNNERS: Record<
       visibility: args.visibility as string | undefined,
       classNames: args.classNames as string[] | undefined,
     }),
+  datasets_delete: (client, args) =>
+    datasetsDelete(client, args.dataset as string),
   projects_delete: (client, args) =>
     projectsDelete(client, args.project as string),
   models_get: (client, args) =>
@@ -172,6 +175,7 @@ describe("parity fixtures", () => {
       [
         "model_download_signed_url.json",
         "datasets_create.json",
+        "datasets_delete.json",
         "models_get.json",
         "projects_create.json",
         "projects_delete.json",

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -53,4 +53,7 @@ test("server registers all available tools over the protocol", async () => {
     "task",
     "slug",
   ]);
+
+  const datasetsDelete = tools.find((tool) => tool.name === "datasets_delete");
+  expect(datasetsDelete?.inputSchema?.required).toEqual(["dataset"]);
 });

--- a/tests/tools/datasets.test.ts
+++ b/tests/tools/datasets.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import { UltralyticsClient } from "../../src/client.js";
 import {
   datasetsCreate,
+  datasetsDelete,
   datasetsGet,
   datasetsList,
 } from "../../src/tools/datasets.js";
@@ -150,6 +151,28 @@ describe("datasetsCreate", () => {
     });
     expect(result.summary).toBe(
       `Created dataset ${"d".repeat(24)} slug=data task=detect.`,
+    );
+  });
+});
+
+describe("datasetsDelete", () => {
+  test("resolves a reference and deletes the dataset", async () => {
+    const { client, calls } = captureClient((url) => {
+      const parsed = new URL(url);
+      if (parsed.pathname === "/api/datasets") {
+        return jsonResponse({
+          datasets: [{ _id: "d".repeat(24), slug: "data", username: "user" }],
+        });
+      }
+      return jsonResponse({ deleted: true });
+    });
+    const result = await datasetsDelete(client, "user/data");
+    expect(calls.at(-1)).toMatchObject({
+      url: `${BASE}/datasets/${"d".repeat(24)}`,
+      method: "DELETE",
+    });
+    expect(result.summary).toBe(
+      `Deleted dataset ${"d".repeat(24)} (soft delete).`,
     );
   });
 });


### PR DESCRIPTION
## Summary
Add MCP support for soft-deleting datasets from Ultralytics Platform.

## Motivation
This rounds out another core dataset-management operation while keeping the write-tool rollout small and easy to review.

## Key Changes
- add `datasets_delete` tool wiring and dataset delete helper
- resolve dataset references before issuing delete requests
- add tests, parity fixture, and README sync for `datasets_delete`