### PR TITLE
ci: trigger release after tag push

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -92,14 +92,16 @@ jobs:
             gh pr edit "$BRANCH" \
               --title "chore: bump version to ${{ steps.version.outputs.next_tag }}" \
               --body "$BODY" \
-              --add-label enhancement
+              --add-label release \
+              --add-label ci
           else
             gh pr create \
               --base main \
               --head "$BRANCH" \
               --title "chore: bump version to ${{ steps.version.outputs.next_tag }}" \
               --body "$BODY" \
-              --label enhancement
+              --label release \
+              --label ci
           fi
 
       - name: Check if tag exists
@@ -115,6 +117,8 @@ jobs:
 
       - name: Create and push tag
         if: steps.version.outputs.ready_to_tag == 'true' && steps.tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           git config user.name "github-actions[bot]"
@@ -122,3 +126,4 @@ jobs:
 
           git tag -a "${{ steps.version.outputs.next_tag }}" -m "Release ${{ steps.version.outputs.next_tag }}"
           git push origin "${{ steps.version.outputs.next_tag }}"
+          gh workflow run "Release" --ref main -f tag="${{ steps.version.outputs.next_tag }}"


### PR DESCRIPTION
## Summary
Fix release preparation workflow so automated tag creation also starts the publish workflow.

## Motivation
The current release prep flow still requires a manual Release run after the tag is pushed. This closes that gap and also applies cleaner labels to automated bump PRs.

## Key Changes
- trigger `Release` explicitly after `prepare-release.yml` pushes a new tag
- switch automated version bump PR labels from `enhancement` to `release` and `ci`
- keep release prep as a manual workflow_dispatch flow