### PR TITLE
feat: add dataset ingest tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Current milestone: read, monitor, predict, export, and initial project and
 dataset lifecycle tools are available. Additional resource-management tools
 land incrementally from here.
 
-## Tools (18)
+## Tools (19)
 
 | Tool | Description |
 | --- | --- |
 | `projects_list` / `projects_get` | Browse projects |
 | `projects_create` / `projects_delete` | Create / soft-delete projects |
-| `datasets_list` / `datasets_get` / `datasets_create` / `datasets_delete` | Browse / create / soft-delete datasets |
+| `datasets_list` / `datasets_get` / `datasets_create` / `datasets_delete` / `dataset_ingest` | Browse / create / soft-delete datasets and start remote ingest jobs |
 | `models_list` / `models_get` | Browse trained models and metrics |
 | `training_monitor` | Status, progress, and latest metrics |
 | `model_predict` | Run inference on an image URL or base64 source |

--- a/fixtures/parity/dataset_ingest.json
+++ b/fixtures/parity/dataset_ingest.json
@@ -1,0 +1,55 @@
+{
+  "tool": "dataset_ingest",
+  "args": {
+    "dataset": "user/data",
+    "sourceUrl": "https://example.com/dataset.zip",
+    "targetSplit": "train"
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/datasets",
+      "query": {
+        "slug": "data",
+        "username": "user"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "datasets": [
+            {
+              "_id": "dddddddddddddddddddddddd",
+              "slug": "data",
+              "username": "user"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/datasets/ingest",
+      "json": {
+        "datasetId": "dddddddddddddddddddddddd",
+        "sourceUrl": "https://example.com/dataset.zip",
+        "targetSplit": "train"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "jobId": "job_123",
+          "datasetId": "dddddddddddddddddddddddd",
+          "status": "queued"
+        }
+      }
+    }
+  ],
+  "expected": {
+    "summary": "Started dataset ingest job job_123 for dataset dddddddddddddddddddddddd.",
+    "data": {
+      "jobId": "job_123",
+      "datasetId": "dddddddddddddddddddddddd",
+      "status": "queued"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ultralytics-mcp",
   "version": "0.1.1",
-  "description": "TypeScript MCP server for the Ultralytics Platform REST API.",
+  "description": "MCP for Ultralytics Platform workflows, datasets, training, prediction, and model operations.",
   "type": "module",
   "bin": {
     "ultralytics-mcp": "./dist/cli.js"

--- a/src/tools/datasets.ts
+++ b/src/tools/datasets.ts
@@ -14,9 +14,20 @@ const DATASET_TASKS = new Set([
   "obb",
 ]);
 
+const TARGET_SPLITS = new Set(["train", "val", "test"]);
+
 function resourceId(item: Record<string, unknown>, fallback?: string): string {
   const value = item._id ?? item.id ?? item.projectId ?? item.datasetId;
   return String(value ?? fallback ?? "None");
+}
+
+function validateTargetSplit(targetSplit?: string): void {
+  if (targetSplit !== undefined && !TARGET_SPLITS.has(targetSplit)) {
+    const allowed = Array.from(TARGET_SPLITS).sort().join(", ");
+    throw new Error(
+      `Unsupported targetSplit '${targetSplit}'. Expected one of: ${allowed}.`,
+    );
+  }
 }
 
 /** List datasets in the workspace, optionally filtered by username. */
@@ -119,5 +130,39 @@ export async function datasetsDelete(
   return {
     summary: `Deleted dataset ${datasetId} (soft delete).`,
     data: { id: datasetId, response: data },
+  };
+}
+
+export interface DatasetsIngestOptions {
+  dataset: string;
+  sourceUrl: string;
+  targetSplit?: string;
+}
+
+/** Start a remote URL ingest job for an existing dataset. */
+export async function datasetsIngest(
+  client: UltralyticsClient,
+  options: DatasetsIngestOptions,
+): Promise<NormalizedToolResult> {
+  if (!options.sourceUrl.trim()) {
+    throw new Error("`sourceUrl` is required.");
+  }
+  validateTargetSplit(options.targetSplit);
+
+  const datasetId = await resolveDataset(client, options.dataset);
+  const payload: Record<string, unknown> = {
+    datasetId,
+    sourceUrl: options.sourceUrl,
+  };
+  if (options.targetSplit !== undefined) {
+    payload.targetSplit = options.targetSplit;
+  }
+
+  const data = await client.postJson("/datasets/ingest", payload);
+  const item = asRecord(data);
+  const jobId = item.jobId ?? item.id ?? "None";
+  return {
+    summary: `Started dataset ingest job ${String(jobId)} for dataset ${datasetId}.`,
+    data: item,
   };
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,6 +15,7 @@ import {
   datasetsCreate,
   datasetsDelete,
   datasetsGet,
+  datasetsIngest,
   datasetsList,
 } from "./datasets.js";
 import { modelDownload } from "./downloads.js";
@@ -34,6 +35,7 @@ export {
   datasetsCreate,
   datasetsDelete,
   datasetsGet,
+  datasetsIngest,
   datasetsList,
 } from "./datasets.js";
 export { modelDownload } from "./downloads.js";
@@ -59,6 +61,7 @@ export const READ_TOOL_NAMES = [
   "datasets_get",
   "datasets_create",
   "datasets_delete",
+  "dataset_ingest",
   "models_list",
   "models_get",
   "gpu_availability",
@@ -174,6 +177,22 @@ export function registerReadTools(
     },
     async ({ dataset }) =>
       toMcpTextResult(await datasetsDelete(getClient(), dataset)),
+  );
+
+  server.registerTool(
+    "dataset_ingest",
+    {
+      description: "Start a remote URL ingest job for an existing dataset.",
+      inputSchema: {
+        dataset: z.string(),
+        sourceUrl: z.string(),
+        targetSplit: z.string().optional(),
+      },
+    },
+    async ({ dataset, sourceUrl, targetSplit }) =>
+      toMcpTextResult(
+        await datasetsIngest(getClient(), { dataset, sourceUrl, targetSplit }),
+      ),
   );
 
   server.registerTool(

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -12,6 +12,7 @@ import type { NormalizedToolResult } from "../src/tool-result.js";
 import {
   datasetsCreate,
   datasetsDelete,
+  datasetsIngest,
   modelDownload,
   modelsGet,
   projectsCreate,
@@ -133,6 +134,12 @@ const TOOL_RUNNERS: Record<
     }),
   datasets_delete: (client, args) =>
     datasetsDelete(client, args.dataset as string),
+  dataset_ingest: (client, args) =>
+    datasetsIngest(client, {
+      dataset: args.dataset as string,
+      sourceUrl: args.sourceUrl as string,
+      targetSplit: args.targetSplit as string | undefined,
+    }),
   projects_delete: (client, args) =>
     projectsDelete(client, args.project as string),
   models_get: (client, args) =>
@@ -176,6 +183,7 @@ describe("parity fixtures", () => {
         "model_download_signed_url.json",
         "datasets_create.json",
         "datasets_delete.json",
+        "dataset_ingest.json",
         "models_get.json",
         "projects_create.json",
         "projects_delete.json",

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -56,4 +56,10 @@ test("server registers all available tools over the protocol", async () => {
 
   const datasetsDelete = tools.find((tool) => tool.name === "datasets_delete");
   expect(datasetsDelete?.inputSchema?.required).toEqual(["dataset"]);
+
+  const datasetIngest = tools.find((tool) => tool.name === "dataset_ingest");
+  expect(datasetIngest?.inputSchema?.required).toEqual([
+    "dataset",
+    "sourceUrl",
+  ]);
 });

--- a/tests/tools/datasets.test.ts
+++ b/tests/tools/datasets.test.ts
@@ -5,6 +5,7 @@ import {
   datasetsCreate,
   datasetsDelete,
   datasetsGet,
+  datasetsIngest,
   datasetsList,
 } from "../../src/tools/datasets.js";
 import { BASE, jsonResponse, KEY, routeClient } from "../helpers.js";
@@ -174,5 +175,64 @@ describe("datasetsDelete", () => {
     expect(result.summary).toBe(
       `Deleted dataset ${"d".repeat(24)} (soft delete).`,
     );
+  });
+});
+
+describe("datasetsIngest", () => {
+  test("resolves a dataset and posts the ingest payload", async () => {
+    const { client, calls } = captureClient((url) => {
+      const parsed = new URL(url);
+      if (parsed.pathname === "/api/datasets") {
+        return jsonResponse({
+          datasets: [{ _id: "d".repeat(24), slug: "data", username: "user" }],
+        });
+      }
+      return jsonResponse({
+        jobId: "job_123",
+        datasetId: "d".repeat(24),
+        status: "queued",
+      });
+    });
+    const result = await datasetsIngest(client, {
+      dataset: "user/data",
+      sourceUrl: "https://example.com/dataset.zip",
+      targetSplit: "train",
+    });
+    expect(calls.at(-1)).toEqual({
+      url: `${BASE}/datasets/ingest`,
+      method: "POST",
+      body: {
+        datasetId: "d".repeat(24),
+        sourceUrl: "https://example.com/dataset.zip",
+        targetSplit: "train",
+      },
+    });
+    expect(result.summary).toBe(
+      `Started dataset ingest job job_123 for dataset ${"d".repeat(24)}.`,
+    );
+    expect((result.data as Record<string, unknown>).status).toBe("queued");
+  });
+
+  test("validates inputs before network", async () => {
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: (async () => {
+        throw new Error("network should not be called");
+      }) as unknown as typeof fetch,
+    });
+    await expect(
+      datasetsIngest(client, {
+        dataset: "user/data",
+        sourceUrl: "",
+      }),
+    ).rejects.toThrow(/`sourceUrl` is required/);
+    await expect(
+      datasetsIngest(client, {
+        dataset: "user/data",
+        sourceUrl: "https://example.com/dataset.zip",
+        targetSplit: "bad",
+      }),
+    ).rejects.toThrow(/Unsupported targetSplit/);
   });
 });


### PR DESCRIPTION
## Summary
Add MCP support for starting remote dataset ingest jobs in Ultralytics Platform.

## Motivation
This adds the next dataset-management write operation while keeping the ingest flow isolated and easy to review on its own.

## Key Changes
- add `dataset_ingest` tool wiring and ingest helper
- validate required source URL and allowed target split values before network calls
- add tests, parity fixture, README sync, and package description refinement