### PR TITLE
feat: add dataset upload file tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Current milestone: read, monitor, predict, export, and initial project and
 dataset lifecycle tools are available. Additional resource-management tools
 land incrementally from here.
 
-## Tools (19)
+## Tools (20)
 
 | Tool | Description |
 | --- | --- |
 | `projects_list` / `projects_get` | Browse projects |
 | `projects_create` / `projects_delete` | Create / soft-delete projects |
-| `datasets_list` / `datasets_get` / `datasets_create` / `datasets_delete` / `dataset_ingest` | Browse / create / soft-delete datasets and start remote ingest jobs |
+| `datasets_list` / `datasets_get` / `datasets_create` / `datasets_delete` / `dataset_ingest` / `dataset_upload_file` | Browse / create / soft-delete datasets, start remote ingest jobs, and upload archive files |
 | `models_list` / `models_get` | Browse trained models and metrics |
 | `training_monitor` | Status, progress, and latest metrics |
 | `model_predict` | Run inference on an image URL or base64 source |

--- a/fixtures/parity/dataset_upload_file.json
+++ b/fixtures/parity/dataset_upload_file.json
@@ -1,0 +1,97 @@
+{
+  "tool": "dataset_upload_file",
+  "args": {
+    "dataset": "user/data",
+    "file_path": "__TMP__/dataset.zip",
+    "targetSplit": "train"
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/datasets",
+      "query": {
+        "slug": "data",
+        "username": "user"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "datasets": [
+            {
+              "_id": "dddddddddddddddddddddddd",
+              "slug": "data",
+              "username": "user"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/upload/signed-url",
+      "json": {
+        "assetType": "datasets",
+        "assetId": "dddddddddddddddddddddddd",
+        "filename": "dataset.zip",
+        "contentType": "application/zip",
+        "totalBytes": 7
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "url": "https://signed.example/upload",
+          "sessionId": "session_123"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/upload/complete",
+      "json": {
+        "sessionId": "session_123"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "ok": true
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/datasets/ingest",
+      "json": {
+        "datasetId": "dddddddddddddddddddddddd",
+        "sessionId": "session_123",
+        "targetSplit": "train"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "jobId": "job_123",
+          "datasetId": "dddddddddddddddddddddddd",
+          "status": "queued"
+        }
+      }
+    }
+  ],
+  "upload": {
+    "url": "https://signed.example/upload",
+    "content_type": "application/zip",
+    "body_text": "archive"
+  },
+  "expected": {
+    "summary": "Uploaded dataset.zip (7 bytes) and started dataset ingest job job_123.",
+    "data": {
+      "datasetId": "dddddddddddddddddddddddd",
+      "filename": "dataset.zip",
+      "bytes": 7,
+      "sessionId": "session_123",
+      "ingest": {
+        "jobId": "job_123",
+        "datasetId": "dddddddddddddddddddddddd",
+        "status": "queued"
+      }
+    }
+  }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,6 +23,7 @@ export interface ClientOptions {
   maxRetries?: number;
   fetchImpl?: FetchLike;
   downloadFetchImpl?: FetchLike;
+  uploadFetchImpl?: FetchLike;
 }
 
 export interface MultipartFile {
@@ -47,6 +48,7 @@ export class UltralyticsClient {
   private readonly maxRetries: number;
   private readonly fetchImpl: FetchLike;
   private readonly downloadFetchImpl: FetchLike;
+  private readonly uploadFetchImpl: FetchLike;
 
   constructor(options: ClientOptions = {}) {
     this.baseUrl = (options.baseUrl ?? getApiBase()).replace(/\/+$/, "");
@@ -55,6 +57,7 @@ export class UltralyticsClient {
     this.maxRetries = options.maxRetries ?? 3;
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.downloadFetchImpl = options.downloadFetchImpl ?? fetch;
+    this.uploadFetchImpl = options.uploadFetchImpl ?? fetch;
   }
 
   // -- public verbs --------------------------------------------------------
@@ -134,6 +137,28 @@ export class UltralyticsClient {
       await this.handle(response, url); // throws UltralyticsApiError
       throw new Error("unreachable");
     }
+  }
+
+  /** Upload bytes to a signed URL WITHOUT forwarding API credentials. */
+  async uploadBytes(
+    url: string,
+    content: Uint8Array,
+    contentType: string,
+  ): Promise<void> {
+    const bytes = new Uint8Array(content.byteLength);
+    bytes.set(content);
+    const response = await this.fetchWithTimeout(this.uploadFetchImpl, url, {
+      method: "PUT",
+      headers: {
+        Accept: "*/*",
+        "Content-Type": contentType,
+      },
+      body: bytes,
+    });
+    if (response.ok) {
+      return;
+    }
+    await this.handle(response, url);
   }
 
   // -- internals -----------------------------------------------------------

--- a/src/tools/datasets.ts
+++ b/src/tools/datasets.ts
@@ -1,5 +1,8 @@
 /** Read-only dataset tools. */
 
+import { readFile, stat } from "node:fs/promises";
+import { basename } from "node:path";
+
 import type { UltralyticsClient } from "../client.js";
 import { resolveDataset } from "../resolve.js";
 import type { NormalizedToolResult } from "../tool-result.js";
@@ -15,6 +18,14 @@ const DATASET_TASKS = new Set([
 ]);
 
 const TARGET_SPLITS = new Set(["train", "val", "test"]);
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024 * 1024;
+const UPLOAD_TYPES: Array<[suffix: string, contentType: string]> = [
+  [".tar.gz", "application/gzip"],
+  [".zip", "application/zip"],
+  [".tar", "application/x-tar"],
+  [".tgz", "application/gzip"],
+  [".ndjson", "application/x-ndjson"],
+];
 
 function resourceId(item: Record<string, unknown>, fallback?: string): string {
   const value = item._id ?? item.id ?? item.projectId ?? item.datasetId;
@@ -28,6 +39,42 @@ function validateTargetSplit(targetSplit?: string): void {
       `Unsupported targetSplit '${targetSplit}'. Expected one of: ${allowed}.`,
     );
   }
+}
+
+async function datasetUploadFileMeta(filePath: string): Promise<{
+  filename: string;
+  contentType: string;
+  totalBytes: number;
+}> {
+  if (!filePath.trim()) {
+    throw new Error("`filePath` is required.");
+  }
+
+  const info = await stat(filePath).catch(() => null);
+  if (info === null) {
+    throw new Error(`Upload file does not exist: ${filePath}`);
+  }
+  if (!info.isFile()) {
+    throw new Error(`Upload path is not a file: ${filePath}`);
+  }
+  if (info.size >= MAX_UPLOAD_BYTES) {
+    throw new Error("Upload file must be smaller than 10 GB.");
+  }
+
+  const filename = basename(filePath);
+  const lower = filename.toLowerCase();
+  const matched = UPLOAD_TYPES.find(([suffix]) => lower.endsWith(suffix));
+  if (!matched) {
+    throw new Error(
+      "Unsupported dataset upload file type. Expected one of: .zip, .tar, .tar.gz, .tgz, .ndjson.",
+    );
+  }
+
+  return {
+    filename,
+    contentType: matched[1],
+    totalBytes: info.size,
+  };
 }
 
 /** List datasets in the workspace, optionally filtered by username. */
@@ -164,5 +211,57 @@ export async function datasetsIngest(
   return {
     summary: `Started dataset ingest job ${String(jobId)} for dataset ${datasetId}.`,
     data: item,
+  };
+}
+
+export interface DatasetUploadFileOptions {
+  dataset: string;
+  filePath: string;
+  targetSplit?: string;
+}
+
+/** Upload a local dataset archive file, then start ingest for that upload. */
+export async function datasetUploadFile(
+  client: UltralyticsClient,
+  options: DatasetUploadFileOptions,
+): Promise<NormalizedToolResult> {
+  validateTargetSplit(options.targetSplit);
+
+  const meta = await datasetUploadFileMeta(options.filePath);
+  const datasetId = await resolveDataset(client, options.dataset);
+  const content = await readFile(options.filePath);
+
+  const signed = asRecord(
+    await client.postJson("/upload/signed-url", {
+      assetType: "datasets",
+      assetId: datasetId,
+      filename: meta.filename,
+      contentType: meta.contentType,
+      totalBytes: meta.totalBytes,
+    }),
+  );
+  const uploadUrl = String(signed.url ?? "");
+  const sessionId = String(signed.sessionId ?? "");
+  await client.uploadBytes(uploadUrl, content, meta.contentType);
+  await client.postJson("/upload/complete", { sessionId });
+
+  const ingestPayload: Record<string, unknown> = { datasetId, sessionId };
+  if (options.targetSplit !== undefined) {
+    ingestPayload.targetSplit = options.targetSplit;
+  }
+  const ingest = asRecord(
+    await client.postJson("/datasets/ingest", ingestPayload),
+  );
+  const jobId = ingest.jobId ?? ingest.id ?? "None";
+
+  return {
+    summary: `Uploaded ${meta.filename} (${meta.totalBytes} bytes) and started dataset ingest job ${String(jobId)}.`,
+    data: {
+      datasetId,
+      filename: meta.filename,
+      bytes: meta.totalBytes,
+      sessionId,
+      ingest,
+    },
   };
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -17,6 +17,7 @@ import {
   datasetsGet,
   datasetsIngest,
   datasetsList,
+  datasetUploadFile,
 } from "./datasets.js";
 import { modelDownload } from "./downloads.js";
 import { exportCreate, exportStatus, exportsList } from "./exports.js";
@@ -37,6 +38,7 @@ export {
   datasetsGet,
   datasetsIngest,
   datasetsList,
+  datasetUploadFile,
 } from "./datasets.js";
 export { modelDownload } from "./downloads.js";
 export { exportCreate, exportStatus, exportsList } from "./exports.js";
@@ -62,6 +64,7 @@ export const READ_TOOL_NAMES = [
   "datasets_create",
   "datasets_delete",
   "dataset_ingest",
+  "dataset_upload_file",
   "models_list",
   "models_get",
   "gpu_availability",
@@ -192,6 +195,27 @@ export function registerReadTools(
     async ({ dataset, sourceUrl, targetSplit }) =>
       toMcpTextResult(
         await datasetsIngest(getClient(), { dataset, sourceUrl, targetSplit }),
+      ),
+  );
+
+  server.registerTool(
+    "dataset_upload_file",
+    {
+      description:
+        "Upload a local dataset archive file and start ingest for an existing dataset.",
+      inputSchema: {
+        dataset: z.string(),
+        file_path: z.string(),
+        targetSplit: z.string().optional(),
+      },
+    },
+    async ({ dataset, file_path, targetSplit }) =>
+      toMcpTextResult(
+        await datasetUploadFile(getClient(), {
+          dataset,
+          filePath: file_path,
+          targetSplit,
+        }),
       ),
   );
 

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,6 +13,7 @@ import {
   datasetsCreate,
   datasetsDelete,
   datasetsIngest,
+  datasetUploadFile,
   modelDownload,
   modelsGet,
   projectsCreate,
@@ -40,11 +41,18 @@ const downloadSchema = z.object({
   body_text: z.string(),
 });
 
+const uploadSchema = z.object({
+  url: z.string().url(),
+  content_type: z.string(),
+  body_text: z.string(),
+});
+
 const fixtureSchema = z.object({
   tool: z.string(),
   args: z.record(z.string(), z.unknown()),
   api: z.array(apiStepSchema),
   download: downloadSchema.optional(),
+  upload: uploadSchema.optional(),
   expected: z.object({
     summary: z.string(),
     data: z.unknown(),
@@ -140,6 +148,12 @@ const TOOL_RUNNERS: Record<
       sourceUrl: args.sourceUrl as string,
       targetSplit: args.targetSplit as string | undefined,
     }),
+  dataset_upload_file: (client, args) =>
+    datasetUploadFile(client, {
+      dataset: args.dataset as string,
+      filePath: args.file_path as string,
+      targetSplit: args.targetSplit as string | undefined,
+    }),
   projects_delete: (client, args) =>
     projectsDelete(client, args.project as string),
   models_get: (client, args) =>
@@ -184,6 +198,7 @@ describe("parity fixtures", () => {
         "datasets_create.json",
         "datasets_delete.json",
         "dataset_ingest.json",
+        "dataset_upload_file.json",
         "models_get.json",
         "projects_create.json",
         "projects_delete.json",
@@ -205,6 +220,7 @@ describe("parity fixtures", () => {
   for (const fixtureFile of fixtureFiles) {
     const raw = readFileSync(join(fixtureDir, fixtureFile), "utf8");
     const fixture = fixtureSchema.parse(JSON.parse(raw));
+    if (fixture.tool === "dataset_upload_file") continue;
     const runner = TOOL_RUNNERS[fixture.tool];
     if (!runner) continue; // tool not ported yet; schema-validated above
 
@@ -260,6 +276,57 @@ describe("parity fixtures", () => {
       expect(downloadAuth).toBeUndefined();
       const written = await readFile(join(tmp, "best.pt"), "utf8");
       expect(written).toBe(fixture.download?.body_text);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("parity output: dataset_upload_file.json", async () => {
+    const raw = readFileSync(
+      join(fixtureDir, "dataset_upload_file.json"),
+      "utf8",
+    );
+    const fixture = fixtureSchema.parse(JSON.parse(raw));
+    const tmp = await mkdtemp(join(tmpdir(), "ul-mcp-"));
+    try {
+      const args = replaceTmp(fixture.args, tmp) as Record<string, unknown>;
+      const expected = replaceTmp(fixture.expected, tmp);
+      await writeFile(
+        args.file_path as string,
+        fixture.upload?.body_text ?? "",
+      );
+
+      let uploadAuth: string | null | undefined = "unset";
+      const uploadFetch = (async (
+        url: string | URL,
+        init: RequestInit = {},
+      ) => {
+        const headers = new Headers(init.headers);
+        uploadAuth = headers.get("Authorization");
+        expect(String(url)).toBe(fixture.upload?.url);
+        expect((init.method ?? "GET").toUpperCase()).toBe("PUT");
+        expect(headers.get("Content-Type")).toBe(fixture.upload?.content_type);
+        expect(await new Response(init.body).text()).toBe(
+          fixture.upload?.body_text ?? "",
+        );
+        return new Response("", { status: 200 });
+      }) as unknown as typeof fetch;
+
+      const client = new UltralyticsClient({
+        apiKey: KEY,
+        baseUrl: BASE,
+        fetchImpl: replayFetch(fixture.api),
+        uploadFetchImpl: uploadFetch,
+      });
+
+      const result = await datasetUploadFile(client, {
+        dataset: args.dataset as string,
+        filePath: args.file_path as string,
+        targetSplit: args.targetSplit as string | undefined,
+      });
+
+      expect(result).toEqual(expected);
+      expect(uploadAuth).toBeNull();
     } finally {
       await rm(tmp, { recursive: true, force: true });
     }

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -62,4 +62,12 @@ test("server registers all available tools over the protocol", async () => {
     "dataset",
     "sourceUrl",
   ]);
+
+  const datasetUploadFile = tools.find(
+    (tool) => tool.name === "dataset_upload_file",
+  );
+  expect(datasetUploadFile?.inputSchema?.required).toEqual([
+    "dataset",
+    "file_path",
+  ]);
 });

--- a/tests/tools/datasets.test.ts
+++ b/tests/tools/datasets.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 
 import { UltralyticsClient } from "../../src/client.js";
@@ -7,6 +10,7 @@ import {
   datasetsGet,
   datasetsIngest,
   datasetsList,
+  datasetUploadFile,
 } from "../../src/tools/datasets.js";
 import { BASE, jsonResponse, KEY, routeClient } from "../helpers.js";
 
@@ -231,6 +235,176 @@ describe("datasetsIngest", () => {
       datasetsIngest(client, {
         dataset: "user/data",
         sourceUrl: "https://example.com/dataset.zip",
+        targetSplit: "bad",
+      }),
+    ).rejects.toThrow(/Unsupported targetSplit/);
+  });
+});
+
+describe("datasetUploadFile", () => {
+  test("uploads file through signed URL flow and starts ingest", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "ul-mcp-upload-"));
+    const filePath = join(tmp, "dataset.zip");
+    await writeFile(filePath, "archive");
+
+    const calls: { url: string; method: string; body: unknown }[] = [];
+    const uploadCalls: Array<{
+      url: string;
+      method: string;
+      body: string;
+      contentType: string | null;
+      auth: string | null;
+    }> = [];
+    const fetchImpl = (async (url: string | URL, init: RequestInit = {}) => {
+      let body: unknown;
+      if (typeof init.body === "string") {
+        body = JSON.parse(init.body);
+      }
+      calls.push({
+        url: String(url),
+        method: (init.method ?? "GET").toUpperCase(),
+        body,
+      });
+      const parsed = new URL(String(url));
+      if (parsed.pathname === "/api/datasets") {
+        return jsonResponse({
+          datasets: [{ _id: "d".repeat(24), slug: "data", username: "user" }],
+        });
+      }
+      if (parsed.pathname === "/api/upload/signed-url") {
+        return jsonResponse({
+          url: "https://signed.example/upload",
+          sessionId: "session_123",
+        });
+      }
+      if (parsed.pathname === "/api/upload/complete") {
+        return jsonResponse({ ok: true });
+      }
+      return jsonResponse({
+        jobId: "job_123",
+        datasetId: "d".repeat(24),
+        status: "queued",
+      });
+    }) as unknown as typeof fetch;
+
+    const uploadFetch = (async (url: string | URL, init: RequestInit = {}) => {
+      uploadCalls.push({
+        url: String(url),
+        method: (init.method ?? "GET").toUpperCase(),
+        body: await new Response(init.body).text(),
+        contentType: new Headers(init.headers).get("Content-Type"),
+        auth: new Headers(init.headers).get("Authorization"),
+      });
+      return new Response("", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const uploadClient = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl,
+      uploadFetchImpl: uploadFetch,
+    });
+
+    const result = await datasetUploadFile(uploadClient, {
+      dataset: "user/data",
+      filePath,
+      targetSplit: "train",
+    });
+
+    expect(calls.map((call) => call.url)).toEqual([
+      `${BASE}/datasets?slug=data&username=user`,
+      `${BASE}/upload/signed-url`,
+      `${BASE}/upload/complete`,
+      `${BASE}/datasets/ingest`,
+    ]);
+    expect(calls[1]).toEqual({
+      url: `${BASE}/upload/signed-url`,
+      method: "POST",
+      body: {
+        assetType: "datasets",
+        assetId: "d".repeat(24),
+        filename: "dataset.zip",
+        contentType: "application/zip",
+        totalBytes: 7,
+      },
+    });
+    expect(uploadCalls).toEqual([
+      {
+        url: "https://signed.example/upload",
+        method: "PUT",
+        body: "archive",
+        contentType: "application/zip",
+        auth: null,
+      },
+    ]);
+    expect(calls[2]).toEqual({
+      url: `${BASE}/upload/complete`,
+      method: "POST",
+      body: { sessionId: "session_123" },
+    });
+    expect(calls[3]).toEqual({
+      url: `${BASE}/datasets/ingest`,
+      method: "POST",
+      body: {
+        datasetId: "d".repeat(24),
+        sessionId: "session_123",
+        targetSplit: "train",
+      },
+    });
+    expect(result.summary).toBe(
+      "Uploaded dataset.zip (7 bytes) and started dataset ingest job job_123.",
+    );
+    expect(result.data).toEqual({
+      datasetId: "d".repeat(24),
+      filename: "dataset.zip",
+      bytes: 7,
+      sessionId: "session_123",
+      ingest: {
+        jobId: "job_123",
+        datasetId: "d".repeat(24),
+        status: "queued",
+      },
+    });
+  });
+
+  test("validates file path and target split before network", async () => {
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: (async () => {
+        throw new Error("network should not be called");
+      }) as unknown as typeof fetch,
+    });
+
+    await expect(
+      datasetUploadFile(client, {
+        dataset: "user/data",
+        filePath: "",
+      }),
+    ).rejects.toThrow(/`filePath` is required/);
+    await expect(
+      datasetUploadFile(client, {
+        dataset: "user/data",
+        filePath: join(tmpdir(), "missing-dataset.zip"),
+      }),
+    ).rejects.toThrow(/does not exist/);
+
+    const tmp = await mkdtemp(join(tmpdir(), "ul-mcp-upload-"));
+    const badPath = join(tmp, "dataset.txt");
+    await writeFile(badPath, "bad");
+    await expect(
+      datasetUploadFile(client, {
+        dataset: "user/data",
+        filePath: badPath,
+      }),
+    ).rejects.toThrow(/Unsupported dataset upload file type/);
+
+    const goodPath = join(tmp, "dataset.zip");
+    await writeFile(goodPath, "archive");
+    await expect(
+      datasetUploadFile(client, {
+        dataset: "user/data",
+        filePath: goodPath,
         targetSplit: "bad",
       }),
     ).rejects.toThrow(/Unsupported targetSplit/);


### PR DESCRIPTION
## Summary
Add MCP support for uploading local dataset archive files to Ultralytics Platform.

## Motivation
This adds next dataset-management write operation while keeping upload flow isolated and easy to review on its own.

## Key Changes
- add `dataset_upload_file` tool wiring and signed upload flow
- validate local file path, file type, size, and target split before network calls
- add tests, parity fixture, and README sync for `dataset_upload_file`
