### PR TITLE
feat: add dataset images list tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Current milestone: read, monitor, predict, export, and initial project and
 dataset lifecycle tools are available. Additional resource-management tools
 land incrementally from here.
 
-## Tools (20)
+## Tools (21)
 
 | Tool | Description |
 | --- | --- |
 | `projects_list` / `projects_get` | Browse projects |
 | `projects_create` / `projects_delete` | Create / soft-delete projects |
-| `datasets_list` / `datasets_get` / `datasets_create` / `datasets_delete` / `dataset_ingest` / `dataset_upload_file` | Browse / create / soft-delete datasets, start remote ingest jobs, and upload archive files |
+| `datasets_list` / `datasets_get` / `datasets_create` / `datasets_delete` / `dataset_images_list` / `dataset_ingest` / `dataset_upload_file` | Browse / create / soft-delete datasets, inspect images, start remote ingest jobs, and upload archive files |
 | `models_list` / `models_get` | Browse trained models and metrics |
 | `training_monitor` | Status, progress, and latest metrics |
 | `model_predict` | Run inference on an image URL or base64 source |

--- a/fixtures/parity/dataset_images_list.json
+++ b/fixtures/parity/dataset_images_list.json
@@ -1,0 +1,95 @@
+{
+  "tool": "dataset_images_list",
+  "args": {
+    "dataset": "user/data",
+    "split": "train",
+    "search": "frame",
+    "hasLabel": true,
+    "classIds": ["car", "person"],
+    "limit": 25,
+    "offset": 50,
+    "includeImageUrls": true
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/datasets",
+      "query": {
+        "slug": "data",
+        "username": "user"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "datasets": [
+            {
+              "_id": "dddddddddddddddddddddddd",
+              "slug": "data",
+              "username": "user"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/datasets/dddddddddddddddddddddddd/images",
+      "query": {
+        "split": "train",
+        "search": "frame",
+        "hasLabel": "true",
+        "classIds": "car,person",
+        "limit": "25",
+        "offset": "50",
+        "includeImageUrls": "true"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "images": [
+            {
+              "_id": "iiiiiiiiiiiiiiiiiiiiiiii",
+              "name": "frame-001",
+              "ext": ".jpg",
+              "split": "train",
+              "width": 1280,
+              "height": 720,
+              "labelCount": 3,
+              "bytes": 12345,
+              "imageUrl": "https://cdn.example.com/frame-001.jpg",
+              "thumbnailUrl": "https://cdn.example.com/frame-001-thumb.jpg",
+              "hash": "omitted"
+            }
+          ],
+          "total": 10,
+          "hasMore": true,
+          "classes": [],
+          "errorCount": 0,
+          "nextCursor": "cursor_2"
+        }
+      }
+    }
+  ],
+  "expected": {
+    "summary": "1 image(s) (total 10)",
+    "data": {
+      "total": 10,
+      "hasMore": true,
+      "nextCursor": "cursor_2",
+      "images": [
+        {
+          "id": "iiiiiiiiiiiiiiiiiiiiiiii",
+          "name": "frame-001",
+          "ext": ".jpg",
+          "split": "train",
+          "width": 1280,
+          "height": 720,
+          "labelCount": 3,
+          "bytes": 12345,
+          "imageUrl": "https://cdn.example.com/frame-001.jpg",
+          "thumbnailUrl": "https://cdn.example.com/frame-001-thumb.jpg"
+        }
+      ]
+    }
+  }
+}

--- a/src/tools/datasets.ts
+++ b/src/tools/datasets.ts
@@ -167,6 +167,94 @@ export async function datasetsCreate(
   };
 }
 
+export interface DatasetImagesListOptions {
+  dataset: string;
+  split?: string;
+  search?: string;
+  hasLabel?: boolean;
+  classIds?: string[];
+  limit?: number;
+  offset?: number;
+  includeImageUrls?: boolean;
+}
+
+/** List images in a dataset with optional filtering. */
+export async function datasetImagesList(
+  client: UltralyticsClient,
+  options: DatasetImagesListOptions,
+): Promise<NormalizedToolResult> {
+  if (options.split !== undefined && !TARGET_SPLITS.has(options.split)) {
+    const allowed = Array.from(TARGET_SPLITS).sort().join(", ");
+    throw new Error(
+      `Unsupported split '${options.split}'. Expected one of: ${allowed}.`,
+    );
+  }
+  if (options.limit !== undefined) {
+    if (options.limit <= 0) {
+      throw new Error("`limit` must be greater than 0.");
+    }
+    if (options.limit > 5000) {
+      throw new Error("`limit` must be at most 5000.");
+    }
+  }
+  if (options.offset !== undefined && options.offset < 0) {
+    throw new Error("`offset` must be greater than or equal to 0.");
+  }
+
+  const datasetId = await resolveDataset(client, options.dataset);
+  const params: Record<string, unknown> = {};
+  if (options.split !== undefined) {
+    params.split = options.split;
+  }
+  if (options.search !== undefined) {
+    params.search = options.search;
+  }
+  if (options.hasLabel !== undefined) {
+    params.hasLabel = options.hasLabel;
+  }
+  if (options.classIds && options.classIds.length > 0) {
+    params.classIds = options.classIds.join(",");
+  }
+  if (options.limit !== undefined) {
+    params.limit = options.limit;
+  }
+  if (options.offset !== undefined) {
+    params.offset = options.offset;
+  }
+  if (options.includeImageUrls !== undefined) {
+    params.includeImageUrls = options.includeImageUrls;
+  }
+
+  const data = await client.get(
+    `/datasets/${datasetId}/images`,
+    Object.keys(params).length > 0 ? params : undefined,
+  );
+  const record = asRecord(data);
+  const images = listField(data, "images").map((image) => ({
+    id: image._id ?? image.id ?? null,
+    name: image.name ?? null,
+    ext: image.ext ?? null,
+    split: image.split ?? null,
+    width: image.width ?? null,
+    height: image.height ?? null,
+    labelCount: image.labelCount ?? null,
+    bytes: image.bytes ?? null,
+    ...(image.imageUrl !== undefined ? { imageUrl: image.imageUrl } : {}),
+    ...(image.thumbnailUrl !== undefined
+      ? { thumbnailUrl: image.thumbnailUrl }
+      : {}),
+  }));
+  return {
+    summary: `${images.length} image(s) (total ${String(record.total ?? null)})`,
+    data: {
+      total: record.total ?? null,
+      hasMore: record.hasMore ?? null,
+      nextCursor: record.nextCursor ?? null,
+      images,
+    },
+  };
+}
+
 /** Soft-delete a dataset by id, slug, username/slug, or dataset ul:// URI. */
 export async function datasetsDelete(
   client: UltralyticsClient,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import type { UltralyticsClient } from "../client.js";
 import { toMcpTextResult } from "../tool-result.js";
 import {
+  datasetImagesList,
   datasetsCreate,
   datasetsDelete,
   datasetsGet,
@@ -33,6 +34,7 @@ import {
 import { trainingMonitor, trainingStart } from "./training.js";
 
 export {
+  datasetImagesList,
   datasetsCreate,
   datasetsDelete,
   datasetsGet,
@@ -62,6 +64,7 @@ export const READ_TOOL_NAMES = [
   "datasets_list",
   "datasets_get",
   "datasets_create",
+  "dataset_images_list",
   "datasets_delete",
   "dataset_ingest",
   "dataset_upload_file",
@@ -167,6 +170,45 @@ export function registerReadTools(
           description,
           visibility,
           classNames,
+        }),
+      ),
+  );
+
+  server.registerTool(
+    "dataset_images_list",
+    {
+      description: "List images in a dataset with optional filtering.",
+      inputSchema: {
+        dataset: z.string(),
+        split: z.string().optional(),
+        search: z.string().optional(),
+        hasLabel: z.boolean().optional(),
+        classIds: z.array(z.string()).optional(),
+        limit: z.number().optional(),
+        offset: z.number().optional(),
+        includeImageUrls: z.boolean().optional(),
+      },
+    },
+    async ({
+      dataset,
+      split,
+      search,
+      hasLabel,
+      classIds,
+      limit,
+      offset,
+      includeImageUrls,
+    }) =>
+      toMcpTextResult(
+        await datasetImagesList(getClient(), {
+          dataset,
+          split,
+          search,
+          hasLabel,
+          classIds,
+          limit,
+          offset,
+          includeImageUrls,
         }),
       ),
   );

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { UltralyticsClient } from "../src/client.js";
 import type { NormalizedToolResult } from "../src/tool-result.js";
 import {
+  datasetImagesList,
   datasetsCreate,
   datasetsDelete,
   datasetsIngest,
@@ -140,6 +141,17 @@ const TOOL_RUNNERS: Record<
       visibility: args.visibility as string | undefined,
       classNames: args.classNames as string[] | undefined,
     }),
+  dataset_images_list: (client, args) =>
+    datasetImagesList(client, {
+      dataset: args.dataset as string,
+      split: args.split as string | undefined,
+      search: args.search as string | undefined,
+      hasLabel: args.hasLabel as boolean | undefined,
+      classIds: args.classIds as string[] | undefined,
+      limit: args.limit as number | undefined,
+      offset: args.offset as number | undefined,
+      includeImageUrls: args.includeImageUrls as boolean | undefined,
+    }),
   datasets_delete: (client, args) =>
     datasetsDelete(client, args.dataset as string),
   dataset_ingest: (client, args) =>
@@ -197,6 +209,7 @@ describe("parity fixtures", () => {
         "model_download_signed_url.json",
         "datasets_create.json",
         "datasets_delete.json",
+        "dataset_images_list.json",
         "dataset_ingest.json",
         "dataset_upload_file.json",
         "models_get.json",

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -57,6 +57,11 @@ test("server registers all available tools over the protocol", async () => {
   const datasetsDelete = tools.find((tool) => tool.name === "datasets_delete");
   expect(datasetsDelete?.inputSchema?.required).toEqual(["dataset"]);
 
+  const datasetImagesList = tools.find(
+    (tool) => tool.name === "dataset_images_list",
+  );
+  expect(datasetImagesList?.inputSchema?.required).toEqual(["dataset"]);
+
   const datasetIngest = tools.find((tool) => tool.name === "dataset_ingest");
   expect(datasetIngest?.inputSchema?.required).toEqual([
     "dataset",

--- a/tests/tools/datasets.test.ts
+++ b/tests/tools/datasets.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "vitest";
 
 import { UltralyticsClient } from "../../src/client.js";
 import {
+  datasetImagesList,
   datasetsCreate,
   datasetsDelete,
   datasetsGet,
@@ -115,6 +116,100 @@ describe("datasetsGet", () => {
     );
     const result = await datasetsGet(client, id);
     expect(result.summary).toBe("Dataset 'None' [None], ? images, ? classes.");
+  });
+});
+
+describe("datasetImagesList", () => {
+  test("resolves dataset, builds query, and normalizes images", async () => {
+    const { client, calls } = captureClient((url) => {
+      const parsed = new URL(url);
+      if (parsed.pathname === "/api/datasets") {
+        return jsonResponse({
+          datasets: [{ _id: "d".repeat(24), slug: "data", username: "user" }],
+        });
+      }
+      return jsonResponse({
+        images: [
+          {
+            _id: "i".repeat(24),
+            name: "frame-001",
+            ext: ".jpg",
+            split: "train",
+            width: 1280,
+            height: 720,
+            labelCount: 3,
+            bytes: 12345,
+            imageUrl: "https://cdn.example.com/frame-001.jpg",
+            thumbnailUrl: "https://cdn.example.com/frame-001-thumb.jpg",
+            hash: "omit",
+          },
+        ],
+        total: 10,
+        hasMore: true,
+        classes: [],
+        errorCount: 0,
+        nextCursor: "cursor_2",
+      });
+    });
+
+    const result = await datasetImagesList(client, {
+      dataset: "user/data",
+      split: "train",
+      search: "frame",
+      hasLabel: true,
+      classIds: ["car", "person"],
+      limit: 25,
+      offset: 50,
+      includeImageUrls: true,
+    });
+
+    expect(calls[1]).toEqual({
+      url:
+        `${BASE}/datasets/${"d".repeat(24)}/images` +
+        "?split=train&search=frame&hasLabel=true&classIds=car%2Cperson&limit=25&offset=50&includeImageUrls=true",
+      method: "GET",
+      body: undefined,
+    });
+    expect(result.summary).toBe("1 image(s) (total 10)");
+    expect(result.data).toEqual({
+      total: 10,
+      hasMore: true,
+      nextCursor: "cursor_2",
+      images: [
+        {
+          id: "i".repeat(24),
+          name: "frame-001",
+          ext: ".jpg",
+          split: "train",
+          width: 1280,
+          height: 720,
+          labelCount: 3,
+          bytes: 12345,
+          imageUrl: "https://cdn.example.com/frame-001.jpg",
+          thumbnailUrl: "https://cdn.example.com/frame-001-thumb.jpg",
+        },
+      ],
+    });
+  });
+
+  test("validates split, limit, and offset before network", async () => {
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: (async () => {
+        throw new Error("network should not be called");
+      }) as typeof fetch,
+    });
+
+    await expect(
+      datasetImagesList(client, { dataset: "data", split: "bogus" }),
+    ).rejects.toThrow(/Unsupported split/);
+    await expect(
+      datasetImagesList(client, { dataset: "data", limit: 5001 }),
+    ).rejects.toThrow(/at most 5000/);
+    await expect(
+      datasetImagesList(client, { dataset: "data", offset: -1 }),
+    ).rejects.toThrow(/greater than or equal to 0/);
   });
 });
 


### PR DESCRIPTION
## Summary
Add MCP support for listing dataset images with filtering and paging options.

## Motivation
This adds next dataset inspection tool while keeping image browsing separate and easy to review on its own.

## Key Changes
- add `dataset_images_list` tool wiring and image list normalization
- support dataset image filters for split, search, labels, classes, paging, and image URLs
- add tests, parity fixture, and README sync for `dataset_images_list`
