### PR TITLE
feat: add dataset export tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Current milestone: read, monitor, predict, export, and initial project and
 dataset lifecycle tools are available. Additional resource-management tools
 land incrementally from here.
 
-## Tools (21)
+## Tools (22)
 
 | Tool | Description |
 | --- | --- |
@@ -20,6 +20,7 @@ land incrementally from here.
 | `model_predict` | Run inference on an image URL or base64 source |
 | `model_download` | Download a model weight file to a local path |
 | `gpu_availability` | Cloud GPU stock status |
+| `dataset_export` | Get export link for latest or frozen dataset version |
 | `exports_list` / `export_status` | List / check export jobs |
 | `export_create` | Create an export job — **requires `confirm_cost: true`** |
 | `training_start` | Start cloud training — **requires `confirm_cost: true`** |

--- a/fixtures/parity/dataset_export.json
+++ b/fixtures/parity/dataset_export.json
@@ -1,0 +1,50 @@
+{
+  "tool": "dataset_export",
+  "args": {
+    "dataset": "user/data",
+    "version": 3
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/datasets",
+      "query": {
+        "slug": "data",
+        "username": "user"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "datasets": [
+            {
+              "_id": "dddddddddddddddddddddddd",
+              "slug": "data",
+              "username": "user"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/datasets/dddddddddddddddddddddddd/export",
+      "query": {
+        "v": "3"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "downloadUrl": "https://cdn.example.com/data-v3.ndjson",
+          "cached": false
+        }
+      }
+    }
+  ],
+  "expected": {
+    "summary": "Export link for user/data (version 3, cached=false)",
+    "data": {
+      "downloadUrl": "https://cdn.example.com/data-v3.ndjson",
+      "cached": false
+    }
+  }
+}

--- a/src/tools/datasets.ts
+++ b/src/tools/datasets.ts
@@ -353,3 +353,39 @@ export async function datasetUploadFile(
     },
   };
 }
+
+export interface DatasetExportOptions {
+  dataset: string;
+  version?: number;
+}
+
+/** Get dataset export link for latest or one frozen version. */
+export async function datasetExport(
+  client: UltralyticsClient,
+  options: DatasetExportOptions,
+): Promise<NormalizedToolResult> {
+  if (options.version !== undefined && options.version <= 0) {
+    throw new Error("`version` must be greater than 0.");
+  }
+
+  const datasetId = await resolveDataset(client, options.dataset);
+  const data = asRecord(
+    await client.get(
+      `/datasets/${datasetId}/export`,
+      options.version !== undefined ? { v: options.version } : undefined,
+    ),
+  );
+  const cached =
+    typeof data.cached === "boolean"
+      ? String(data.cached)
+      : String(data.cached ?? null);
+  return {
+    summary:
+      `Export link for ${options.dataset} ` +
+      `(version ${String(options.version ?? "latest")}, cached=${cached})`,
+    data: {
+      downloadUrl: data.downloadUrl ?? null,
+      cached: data.cached ?? null,
+    },
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import type { UltralyticsClient } from "../client.js";
 import { toMcpTextResult } from "../tool-result.js";
 import {
+  datasetExport,
   datasetImagesList,
   datasetsCreate,
   datasetsDelete,
@@ -34,6 +35,7 @@ import {
 import { trainingMonitor, trainingStart } from "./training.js";
 
 export {
+  datasetExport,
   datasetImagesList,
   datasetsCreate,
   datasetsDelete,
@@ -65,6 +67,7 @@ export const READ_TOOL_NAMES = [
   "datasets_get",
   "datasets_create",
   "dataset_images_list",
+  "dataset_export",
   "datasets_delete",
   "dataset_ingest",
   "dataset_upload_file",
@@ -211,6 +214,19 @@ export function registerReadTools(
           includeImageUrls,
         }),
       ),
+  );
+
+  server.registerTool(
+    "dataset_export",
+    {
+      description: "Get export link for latest or one frozen dataset version.",
+      inputSchema: {
+        dataset: z.string(),
+        version: z.number().optional(),
+      },
+    },
+    async ({ dataset, version }) =>
+      toMcpTextResult(await datasetExport(getClient(), { dataset, version })),
   );
 
   server.registerTool(

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { UltralyticsClient } from "../src/client.js";
 import type { NormalizedToolResult } from "../src/tool-result.js";
 import {
+  datasetExport,
   datasetImagesList,
   datasetsCreate,
   datasetsDelete,
@@ -152,6 +153,11 @@ const TOOL_RUNNERS: Record<
       offset: args.offset as number | undefined,
       includeImageUrls: args.includeImageUrls as boolean | undefined,
     }),
+  dataset_export: (client, args) =>
+    datasetExport(client, {
+      dataset: args.dataset as string,
+      version: args.version as number | undefined,
+    }),
   datasets_delete: (client, args) =>
     datasetsDelete(client, args.dataset as string),
   dataset_ingest: (client, args) =>
@@ -209,6 +215,7 @@ describe("parity fixtures", () => {
         "model_download_signed_url.json",
         "datasets_create.json",
         "datasets_delete.json",
+        "dataset_export.json",
         "dataset_images_list.json",
         "dataset_ingest.json",
         "dataset_upload_file.json",

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -62,6 +62,9 @@ test("server registers all available tools over the protocol", async () => {
   );
   expect(datasetImagesList?.inputSchema?.required).toEqual(["dataset"]);
 
+  const datasetExport = tools.find((tool) => tool.name === "dataset_export");
+  expect(datasetExport?.inputSchema?.required).toEqual(["dataset"]);
+
   const datasetIngest = tools.find((tool) => tool.name === "dataset_ingest");
   expect(datasetIngest?.inputSchema?.required).toEqual([
     "dataset",

--- a/tests/tools/datasets.test.ts
+++ b/tests/tools/datasets.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "vitest";
 
 import { UltralyticsClient } from "../../src/client.js";
 import {
+  datasetExport,
   datasetImagesList,
   datasetsCreate,
   datasetsDelete,
@@ -252,6 +253,41 @@ describe("datasetsCreate", () => {
     expect(result.summary).toBe(
       `Created dataset ${"d".repeat(24)} slug=data task=detect.`,
     );
+  });
+});
+
+describe("datasetExport", () => {
+  test("resolves dataset and returns export link", async () => {
+    const { client, calls } = captureClient((url) => {
+      const parsed = new URL(url);
+      if (parsed.pathname === "/api/datasets") {
+        return jsonResponse({
+          datasets: [{ _id: "d".repeat(24), slug: "data", username: "user" }],
+        });
+      }
+      return jsonResponse({
+        downloadUrl: "https://cdn.example.com/data-v3.ndjson",
+        cached: false,
+      });
+    });
+
+    const result = await datasetExport(client, {
+      dataset: "user/data",
+      version: 3,
+    });
+
+    expect(calls[1]).toEqual({
+      url: `${BASE}/datasets/${"d".repeat(24)}/export?v=3`,
+      method: "GET",
+      body: undefined,
+    });
+    expect(result.summary).toBe(
+      "Export link for user/data (version 3, cached=false)",
+    );
+    expect(result.data).toEqual({
+      downloadUrl: "https://cdn.example.com/data-v3.ndjson",
+      cached: false,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
Add MCP support for retrieving dataset export links from Ultralytics Platform.

## Motivation
This adds next dataset versioning/export tool while keeping export retrieval isolated and easy to review on its own.

## Key Changes
- add `dataset_export` tool wiring and export link lookup
- support optional frozen dataset version selection
- add tests, parity fixture, and README sync for `dataset_export`
