### PR TITLE
feat: add dataset version create tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Current milestone: read, monitor, predict, export, and initial project and
 dataset lifecycle tools are available. Additional resource-management tools
 land incrementally from here.
 
-## Tools (22)
+## Tools (23)
 
 | Tool | Description |
 | --- | --- |
@@ -21,6 +21,7 @@ land incrementally from here.
 | `model_download` | Download a model weight file to a local path |
 | `gpu_availability` | Cloud GPU stock status |
 | `dataset_export` | Get export link for latest or frozen dataset version |
+| `dataset_version_create` | Create a frozen dataset version snapshot |
 | `exports_list` / `export_status` | List / check export jobs |
 | `export_create` | Create an export job — **requires `confirm_cost: true`** |
 | `training_start` | Start cloud training — **requires `confirm_cost: true`** |

--- a/fixtures/parity/dataset_version_create.json
+++ b/fixtures/parity/dataset_version_create.json
@@ -1,0 +1,50 @@
+{
+  "tool": "dataset_version_create",
+  "args": {
+    "dataset": "user/data",
+    "description": "Quarterly snapshot"
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/datasets",
+      "query": {
+        "slug": "data",
+        "username": "user"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "datasets": [
+            {
+              "_id": "dddddddddddddddddddddddd",
+              "slug": "data",
+              "username": "user"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/datasets/dddddddddddddddddddddddd/export",
+      "json": {
+        "description": "Quarterly snapshot"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "version": 4,
+          "downloadUrl": "https://cdn.example.com/data-v4.ndjson"
+        }
+      }
+    }
+  ],
+  "expected": {
+    "summary": "Created dataset version 4",
+    "data": {
+      "version": 4,
+      "downloadUrl": "https://cdn.example.com/data-v4.ndjson"
+    }
+  }
+}

--- a/src/tools/datasets.ts
+++ b/src/tools/datasets.ts
@@ -389,3 +389,31 @@ export async function datasetExport(
     },
   };
 }
+
+export interface DatasetVersionCreateOptions {
+  dataset: string;
+  description?: string;
+}
+
+/** Create frozen dataset export version. */
+export async function datasetVersionCreate(
+  client: UltralyticsClient,
+  options: DatasetVersionCreateOptions,
+): Promise<NormalizedToolResult> {
+  const datasetId = await resolveDataset(client, options.dataset);
+  const payload: Record<string, unknown> = {};
+  if (options.description !== undefined) {
+    payload.description = options.description;
+  }
+
+  const data = asRecord(
+    await client.postJson(`/datasets/${datasetId}/export`, payload),
+  );
+  return {
+    summary: `Created dataset version ${String(data.version ?? null)}`,
+    data: {
+      version: data.version ?? null,
+      downloadUrl: data.downloadUrl ?? null,
+    },
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -20,6 +20,7 @@ import {
   datasetsIngest,
   datasetsList,
   datasetUploadFile,
+  datasetVersionCreate,
 } from "./datasets.js";
 import { modelDownload } from "./downloads.js";
 import { exportCreate, exportStatus, exportsList } from "./exports.js";
@@ -43,6 +44,7 @@ export {
   datasetsIngest,
   datasetsList,
   datasetUploadFile,
+  datasetVersionCreate,
 } from "./datasets.js";
 export { modelDownload } from "./downloads.js";
 export { exportCreate, exportStatus, exportsList } from "./exports.js";
@@ -68,6 +70,7 @@ export const READ_TOOL_NAMES = [
   "datasets_create",
   "dataset_images_list",
   "dataset_export",
+  "dataset_version_create",
   "datasets_delete",
   "dataset_ingest",
   "dataset_upload_file",
@@ -227,6 +230,21 @@ export function registerReadTools(
     },
     async ({ dataset, version }) =>
       toMcpTextResult(await datasetExport(getClient(), { dataset, version })),
+  );
+
+  server.registerTool(
+    "dataset_version_create",
+    {
+      description: "Create a frozen dataset version snapshot.",
+      inputSchema: {
+        dataset: z.string(),
+        description: z.string().optional(),
+      },
+    },
+    async ({ dataset, description }) =>
+      toMcpTextResult(
+        await datasetVersionCreate(getClient(), { dataset, description }),
+      ),
   );
 
   server.registerTool(

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -16,6 +16,7 @@ import {
   datasetsDelete,
   datasetsIngest,
   datasetUploadFile,
+  datasetVersionCreate,
   modelDownload,
   modelsGet,
   projectsCreate,
@@ -158,6 +159,11 @@ const TOOL_RUNNERS: Record<
       dataset: args.dataset as string,
       version: args.version as number | undefined,
     }),
+  dataset_version_create: (client, args) =>
+    datasetVersionCreate(client, {
+      dataset: args.dataset as string,
+      description: args.description as string | undefined,
+    }),
   datasets_delete: (client, args) =>
     datasetsDelete(client, args.dataset as string),
   dataset_ingest: (client, args) =>
@@ -218,6 +224,7 @@ describe("parity fixtures", () => {
         "dataset_export.json",
         "dataset_images_list.json",
         "dataset_ingest.json",
+        "dataset_version_create.json",
         "dataset_upload_file.json",
         "models_get.json",
         "projects_create.json",

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -65,6 +65,11 @@ test("server registers all available tools over the protocol", async () => {
   const datasetExport = tools.find((tool) => tool.name === "dataset_export");
   expect(datasetExport?.inputSchema?.required).toEqual(["dataset"]);
 
+  const datasetVersionCreate = tools.find(
+    (tool) => tool.name === "dataset_version_create",
+  );
+  expect(datasetVersionCreate?.inputSchema?.required).toEqual(["dataset"]);
+
   const datasetIngest = tools.find((tool) => tool.name === "dataset_ingest");
   expect(datasetIngest?.inputSchema?.required).toEqual([
     "dataset",

--- a/tests/tools/datasets.test.ts
+++ b/tests/tools/datasets.test.ts
@@ -13,6 +13,7 @@ import {
   datasetsIngest,
   datasetsList,
   datasetUploadFile,
+  datasetVersionCreate,
 } from "../../src/tools/datasets.js";
 import { BASE, jsonResponse, KEY, routeClient } from "../helpers.js";
 
@@ -287,6 +288,41 @@ describe("datasetExport", () => {
     expect(result.data).toEqual({
       downloadUrl: "https://cdn.example.com/data-v3.ndjson",
       cached: false,
+    });
+  });
+});
+
+describe("datasetVersionCreate", () => {
+  test("resolves dataset and posts version snapshot payload", async () => {
+    const { client, calls } = captureClient((url) => {
+      const parsed = new URL(url);
+      if (parsed.pathname === "/api/datasets") {
+        return jsonResponse({
+          datasets: [{ _id: "d".repeat(24), slug: "data", username: "user" }],
+        });
+      }
+      return jsonResponse({
+        version: 4,
+        downloadUrl: "https://cdn.example.com/data-v4.ndjson",
+      });
+    });
+
+    const result = await datasetVersionCreate(client, {
+      dataset: "user/data",
+      description: "Quarterly snapshot",
+    });
+
+    expect(calls[1]).toEqual({
+      url: `${BASE}/datasets/${"d".repeat(24)}/export`,
+      method: "POST",
+      body: {
+        description: "Quarterly snapshot",
+      },
+    });
+    expect(result.summary).toBe("Created dataset version 4");
+    expect(result.data).toEqual({
+      version: 4,
+      downloadUrl: "https://cdn.example.com/data-v4.ndjson",
     });
   });
 });


### PR DESCRIPTION
## Summary
Add MCP support for creating frozen dataset version snapshots on Ultralytics Platform.

## Motivation
This adds next dataset versioning tool while keeping snapshot creation isolated and easy to review on its own.

## Key Changes
- add `dataset_version_create` tool wiring and version snapshot request
- support optional snapshot description payload
- add tests, parity fixture, and README sync for `dataset_version_create`
