### PR TITLE
feat: add dataset upload folder tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Current milestone: read, monitor, predict, export, and initial project and
 dataset lifecycle tools are available. Additional resource-management tools
 land incrementally from here.
 
-## Tools (23)
+## Tools (24)
 
 | Tool | Description |
 | --- | --- |
 | `projects_list` / `projects_get` | Browse projects |
 | `projects_create` / `projects_delete` | Create / soft-delete projects |
-| `datasets_list` / `datasets_get` / `datasets_create` / `datasets_delete` / `dataset_images_list` / `dataset_ingest` / `dataset_upload_file` | Browse / create / soft-delete datasets, inspect images, start remote ingest jobs, and upload archive files |
+| `datasets_list` / `datasets_get` / `datasets_create` / `datasets_delete` / `dataset_images_list` / `dataset_ingest` / `dataset_upload_file` / `dataset_upload_folder` | Browse / create / soft-delete datasets, inspect images, start remote ingest jobs, and upload archive files or folders |
 | `models_list` / `models_get` | Browse trained models and metrics |
 | `training_monitor` | Status, progress, and latest metrics |
 | `model_predict` | Run inference on an image URL or base64 source |

--- a/fixtures/parity/dataset_upload_folder.json
+++ b/fixtures/parity/dataset_upload_folder.json
@@ -1,0 +1,105 @@
+{
+  "tool": "dataset_upload_folder",
+  "args": {
+    "dataset": "user/data",
+    "folder_path": "__TMP__/birds",
+    "targetSplit": "train"
+  },
+  "folder_files": {
+    "bird.jpg": "jpg",
+    "nested/bird.webp": "webp"
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/datasets",
+      "query": {
+        "slug": "data",
+        "username": "user"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "datasets": [
+            {
+              "_id": "dddddddddddddddddddddddd",
+              "slug": "data",
+              "username": "user"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/upload/signed-url",
+      "json": {
+        "assetType": "datasets",
+        "assetId": "dddddddddddddddddddddddd",
+        "filename": "birds.zip",
+        "contentType": "application/zip",
+        "totalBytes": "__ANY_NUMBER__"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "sessionId": "session_123",
+          "uploadUrl": "https://signed.example/upload"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/upload/complete",
+      "json": {
+        "sessionId": "session_123"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "ok": true
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/datasets/ingest",
+      "json": {
+        "datasetId": "dddddddddddddddddddddddd",
+        "sessionId": "session_123",
+        "targetSplit": "train"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "jobId": "job_123",
+          "datasetId": "dddddddddddddddddddddddd",
+          "status": "queued"
+        }
+      }
+    }
+  ],
+  "upload": {
+    "url": "https://signed.example/upload",
+    "content_type": "application/zip",
+    "zip_files": {
+      "bird.jpg": "jpg",
+      "nested/bird.webp": "webp"
+    }
+  },
+  "expected": {
+    "summary": "Zipped 2 image(s) from __TMP__/birds and started ingest job job_123 for dataset dddddddddddddddddddddddd.",
+    "data": {
+      "datasetId": "dddddddddddddddddddddddd",
+      "imageCount": 2,
+      "filename": "birds.zip",
+      "bytes": "__ANY_NUMBER__",
+      "sessionId": "session_123",
+      "ingest": {
+        "jobId": "job_123",
+        "datasetId": "dddddddddddddddddddddddd",
+        "status": "queued"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,11 @@
   "packages": {
     "": {
       "name": "ultralytics-mcp",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "fflate": "^0.8.2",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -1217,6 +1218,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "fflate": "^0.8.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/tools/datasets.ts
+++ b/src/tools/datasets.ts
@@ -1,7 +1,9 @@
 /** Read-only dataset tools. */
 
-import { readFile, stat } from "node:fs/promises";
-import { basename } from "node:path";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { basename, relative, resolve } from "node:path";
+
+import { zipSync } from "fflate";
 
 import type { UltralyticsClient } from "../client.js";
 import { resolveDataset } from "../resolve.js";
@@ -19,6 +21,15 @@ const DATASET_TASKS = new Set([
 
 const TARGET_SPLITS = new Set(["train", "val", "test"]);
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024 * 1024;
+const IMAGE_SUFFIXES = new Set([
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".webp",
+  ".bmp",
+  ".tif",
+  ".tiff",
+]);
 const UPLOAD_TYPES: Array<[suffix: string, contentType: string]> = [
   [".tar.gz", "application/gzip"],
   [".zip", "application/zip"],
@@ -75,6 +86,152 @@ async function datasetUploadFileMeta(filePath: string): Promise<{
     contentType: matched[1],
     totalBytes: info.size,
   };
+}
+
+function skipDatasetFolderPart(part: string): boolean {
+  return part.startsWith(".") || part === "__MACOSX";
+}
+
+function hasSplitLikePath(path: string): boolean {
+  return path.split("/").some((part) => TARGET_SPLITS.has(part.toLowerCase()));
+}
+
+async function datasetFolderImages(folderPath: string): Promise<{
+  folderPath: string;
+  files: Array<{ absolutePath: string; relativePath: string; size: number }>;
+  hasSplitDirs: boolean;
+}> {
+  if (!folderPath.trim()) {
+    throw new Error("`folderPath` is required.");
+  }
+
+  const resolvedFolder = resolve(folderPath);
+  const info = await stat(resolvedFolder).catch(() => null);
+  if (info === null) {
+    throw new Error(`Upload folder does not exist: ${resolvedFolder}`);
+  }
+  if (!info.isDirectory()) {
+    throw new Error(`Upload path is not a directory: ${resolvedFolder}`);
+  }
+
+  const files: Array<{
+    absolutePath: string;
+    relativePath: string;
+    size: number;
+  }> = [];
+  let totalBytes = 0;
+  let hasSplitDirs = false;
+
+  async function walk(currentPath: string): Promise<void> {
+    const entries = await readdir(currentPath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (skipDatasetFolderPart(entry.name) || entry.name === ".DS_Store") {
+        continue;
+      }
+      const absolutePath = resolve(currentPath, entry.name);
+      const relativePath = relative(resolvedFolder, absolutePath).replaceAll(
+        "\\",
+        "/",
+      );
+      if (
+        relativePath
+          .split("/")
+          .some((part) => skipDatasetFolderPart(part) || part === ".DS_Store")
+      ) {
+        continue;
+      }
+      if (entry.isDirectory()) {
+        await walk(absolutePath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      const lower = entry.name.toLowerCase();
+      const archiveSuffix = UPLOAD_TYPES.find(([candidate]) =>
+        lower.endsWith(candidate),
+      );
+      if (archiveSuffix) {
+        continue;
+      }
+      const imageSuffix = Array.from(IMAGE_SUFFIXES).find((candidate) =>
+        lower.endsWith(candidate),
+      );
+      if (!imageSuffix) {
+        continue;
+      }
+      const fileInfo = await stat(absolutePath);
+      totalBytes += fileInfo.size;
+      if (totalBytes >= MAX_UPLOAD_BYTES) {
+        throw new Error(
+          "Upload folder images must be smaller than 10 GB total.",
+        );
+      }
+      if (hasSplitLikePath(relativePath)) {
+        hasSplitDirs = true;
+      }
+      files.push({ absolutePath, relativePath, size: fileInfo.size });
+    }
+  }
+
+  await walk(resolvedFolder);
+  if (files.length === 0) {
+    throw new Error("No images found in folder.");
+  }
+
+  return { folderPath: resolvedFolder, files, hasSplitDirs };
+}
+
+async function buildDatasetFolderZip(
+  files: Array<{ absolutePath: string; relativePath: string }>,
+): Promise<Uint8Array> {
+  const entries: Record<string, Uint8Array> = {};
+  for (const file of files) {
+    entries[file.relativePath] = await readFile(file.absolutePath);
+  }
+  const zipBytes = zipSync(entries, { level: 6 });
+  if (zipBytes.byteLength >= MAX_UPLOAD_BYTES) {
+    throw new Error("Upload zip must be smaller than 10 GB.");
+  }
+  return zipBytes;
+}
+
+async function uploadDatasetContent(
+  client: UltralyticsClient,
+  options: {
+    datasetId: string;
+    filename: string;
+    contentType: string;
+    totalBytes: number;
+    content: Uint8Array;
+    targetSplit?: string;
+  },
+): Promise<{ sessionId: string; ingest: Record<string, unknown> }> {
+  const signed = asRecord(
+    await client.postJson("/upload/signed-url", {
+      assetType: "datasets",
+      assetId: options.datasetId,
+      filename: options.filename,
+      contentType: options.contentType,
+      totalBytes: options.totalBytes,
+    }),
+  );
+  const sessionId = String(signed.sessionId);
+  const uploadUrl = String(signed.uploadUrl ?? signed.url);
+  await client.uploadBytes(uploadUrl, options.content, options.contentType);
+  await client.postJson("/upload/complete", { sessionId });
+
+  const ingestPayload: Record<string, unknown> = {
+    datasetId: options.datasetId,
+    sessionId,
+  };
+  if (options.targetSplit !== undefined) {
+    ingestPayload.targetSplit = options.targetSplit;
+  }
+  const ingest = asRecord(
+    await client.postJson("/datasets/ingest", ingestPayload),
+  );
+  return { sessionId, ingest };
 }
 
 /** List datasets in the workspace, optionally filtered by username. */
@@ -319,27 +476,15 @@ export async function datasetUploadFile(
   const datasetId = await resolveDataset(client, options.dataset);
   const content = await readFile(options.filePath);
 
-  const signed = asRecord(
-    await client.postJson("/upload/signed-url", {
-      assetType: "datasets",
-      assetId: datasetId,
-      filename: meta.filename,
-      contentType: meta.contentType,
-      totalBytes: meta.totalBytes,
-    }),
-  );
-  const uploadUrl = String(signed.url ?? "");
-  const sessionId = String(signed.sessionId ?? "");
-  await client.uploadBytes(uploadUrl, content, meta.contentType);
-  await client.postJson("/upload/complete", { sessionId });
-
-  const ingestPayload: Record<string, unknown> = { datasetId, sessionId };
-  if (options.targetSplit !== undefined) {
-    ingestPayload.targetSplit = options.targetSplit;
-  }
-  const ingest = asRecord(
-    await client.postJson("/datasets/ingest", ingestPayload),
-  );
+  const upload = await uploadDatasetContent(client, {
+    datasetId,
+    filename: meta.filename,
+    contentType: meta.contentType,
+    totalBytes: meta.totalBytes,
+    content,
+    targetSplit: options.targetSplit,
+  });
+  const ingest = upload.ingest;
   const jobId = ingest.jobId ?? ingest.id ?? "None";
 
   return {
@@ -348,8 +493,53 @@ export async function datasetUploadFile(
       datasetId,
       filename: meta.filename,
       bytes: meta.totalBytes,
-      sessionId,
+      sessionId: upload.sessionId,
       ingest,
+    },
+  };
+}
+
+export interface DatasetUploadFolderOptions {
+  dataset: string;
+  folderPath: string;
+  targetSplit?: string;
+}
+
+/** Upload a local image folder as zip, then start dataset ingest for the session. */
+export async function datasetUploadFolder(
+  client: UltralyticsClient,
+  options: DatasetUploadFolderOptions,
+): Promise<NormalizedToolResult> {
+  validateTargetSplit(options.targetSplit);
+
+  const folder = await datasetFolderImages(options.folderPath);
+  if (options.targetSplit !== undefined && folder.hasSplitDirs) {
+    throw new Error(
+      "Folder has split directories (train/val/test); don't also pass targetSplit - it's ambiguous. Use one or the other.",
+    );
+  }
+
+  const datasetId = await resolveDataset(client, options.dataset);
+  const content = await buildDatasetFolderZip(folder.files);
+  const filename = `${basename(folder.folderPath)}.zip`;
+  const upload = await uploadDatasetContent(client, {
+    datasetId,
+    filename,
+    contentType: "application/zip",
+    totalBytes: content.byteLength,
+    content,
+    targetSplit: options.targetSplit,
+  });
+  const jobId = upload.ingest.jobId ?? upload.ingest.id ?? "None";
+  return {
+    summary: `Zipped ${folder.files.length} image(s) from ${folder.folderPath} and started ingest job ${String(jobId)} for dataset ${datasetId}.`,
+    data: {
+      datasetId,
+      imageCount: folder.files.length,
+      filename,
+      bytes: content.byteLength,
+      sessionId: upload.sessionId,
+      ingest: upload.ingest,
     },
   };
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -20,6 +20,7 @@ import {
   datasetsIngest,
   datasetsList,
   datasetUploadFile,
+  datasetUploadFolder,
   datasetVersionCreate,
 } from "./datasets.js";
 import { modelDownload } from "./downloads.js";
@@ -44,6 +45,7 @@ export {
   datasetsIngest,
   datasetsList,
   datasetUploadFile,
+  datasetUploadFolder,
   datasetVersionCreate,
 } from "./datasets.js";
 export { modelDownload } from "./downloads.js";
@@ -74,6 +76,7 @@ export const READ_TOOL_NAMES = [
   "datasets_delete",
   "dataset_ingest",
   "dataset_upload_file",
+  "dataset_upload_folder",
   "models_list",
   "models_get",
   "gpu_availability",
@@ -290,6 +293,27 @@ export function registerReadTools(
         await datasetUploadFile(getClient(), {
           dataset,
           filePath: file_path,
+          targetSplit,
+        }),
+      ),
+  );
+
+  server.registerTool(
+    "dataset_upload_folder",
+    {
+      description:
+        "Upload a local image folder as a zip and start ingest for an existing dataset.",
+      inputSchema: {
+        dataset: z.string(),
+        folder_path: z.string(),
+        targetSplit: z.string().optional(),
+      },
+    },
+    async ({ dataset, folder_path, targetSplit }) =>
+      toMcpTextResult(
+        await datasetUploadFolder(getClient(), {
+          dataset,
+          folderPath: folder_path,
           targetSplit,
         }),
       ),

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -1,8 +1,9 @@
 import { readdirSync, readFileSync } from "node:fs";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { unzipSync } from "fflate";
 
 import { describe, expect, test } from "vitest";
 import { z } from "zod";
@@ -16,6 +17,7 @@ import {
   datasetsDelete,
   datasetsIngest,
   datasetUploadFile,
+  datasetUploadFolder,
   datasetVersionCreate,
   modelDownload,
   modelsGet,
@@ -47,7 +49,8 @@ const downloadSchema = z.object({
 const uploadSchema = z.object({
   url: z.string().url(),
   content_type: z.string(),
-  body_text: z.string(),
+  body_text: z.string().optional(),
+  zip_files: z.record(z.string(), z.string()).optional(),
 });
 
 const fixtureSchema = z.object({
@@ -56,6 +59,7 @@ const fixtureSchema = z.object({
   api: z.array(apiStepSchema),
   download: downloadSchema.optional(),
   upload: uploadSchema.optional(),
+  folder_files: z.record(z.string(), z.string()).optional(),
   expected: z.object({
     summary: z.string(),
     data: z.unknown(),
@@ -66,6 +70,29 @@ type Fixture = z.infer<typeof fixtureSchema>;
 
 const BASE = "https://platform.ultralytics.com/api";
 const KEY = `ul_${"0".repeat(40)}`;
+
+function expectMatch(actual: unknown, expected: unknown): void {
+  if (expected === "__ANY_NUMBER__") {
+    expect(actual).toEqual(expect.any(Number));
+    return;
+  }
+  if (Array.isArray(expected)) {
+    expect(Array.isArray(actual)).toBe(true);
+    expect((actual as unknown[]).length).toBe(expected.length);
+    expected.forEach((item, index) => {
+      expectMatch((actual as unknown[])[index], item);
+    });
+    return;
+  }
+  if (expected && typeof expected === "object") {
+    expect(actual && typeof actual === "object").toBe(true);
+    for (const [key, value] of Object.entries(expected)) {
+      expectMatch((actual as Record<string, unknown>)[key], value);
+    }
+    return;
+  }
+  expect(actual).toEqual(expected);
+}
 
 /** Build a fetch that replays a fixture's recorded API steps.
  *
@@ -99,7 +126,7 @@ function replayFetch(steps: Fixture["api"]): typeof fetch {
       }
       if (!queryMatches) continue;
       if (step.json !== undefined) {
-        expect(JSON.parse(String(init.body))).toEqual(step.json);
+        expectMatch(JSON.parse(String(init.body)), step.json);
       }
 
       entry.used = true;
@@ -164,6 +191,12 @@ const TOOL_RUNNERS: Record<
       dataset: args.dataset as string,
       description: args.description as string | undefined,
     }),
+  dataset_upload_folder: (client, args) =>
+    datasetUploadFolder(client, {
+      dataset: args.dataset as string,
+      folderPath: args.folder_path as string,
+      targetSplit: args.targetSplit as string | undefined,
+    }),
   datasets_delete: (client, args) =>
     datasetsDelete(client, args.dataset as string),
   dataset_ingest: (client, args) =>
@@ -226,6 +259,7 @@ describe("parity fixtures", () => {
         "dataset_ingest.json",
         "dataset_version_create.json",
         "dataset_upload_file.json",
+        "dataset_upload_folder.json",
         "models_get.json",
         "projects_create.json",
         "projects_delete.json",
@@ -247,7 +281,12 @@ describe("parity fixtures", () => {
   for (const fixtureFile of fixtureFiles) {
     const raw = readFileSync(join(fixtureDir, fixtureFile), "utf8");
     const fixture = fixtureSchema.parse(JSON.parse(raw));
-    if (fixture.tool === "dataset_upload_file") continue;
+    if (
+      fixture.tool === "dataset_upload_file" ||
+      fixture.tool === "dataset_upload_folder"
+    ) {
+      continue;
+    }
     const runner = TOOL_RUNNERS[fixture.tool];
     if (!runner) continue; // tool not ported yet; schema-validated above
 
@@ -353,6 +392,69 @@ describe("parity fixtures", () => {
       });
 
       expect(result).toEqual(expected);
+      expect(uploadAuth).toBeNull();
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("parity output: dataset_upload_folder.json", async () => {
+    const raw = readFileSync(
+      join(fixtureDir, "dataset_upload_folder.json"),
+      "utf8",
+    );
+    const fixture = fixtureSchema.parse(JSON.parse(raw));
+    const tmp = await mkdtemp(join(tmpdir(), "ul-mcp-"));
+    try {
+      const args = replaceTmp(fixture.args, tmp) as Record<string, unknown>;
+      const expected = replaceTmp(fixture.expected, tmp);
+      if (fixture.folder_files) {
+        for (const [relativePath, content] of Object.entries(
+          fixture.folder_files,
+        )) {
+          const path = join(args.folder_path as string, relativePath);
+          await mkdir(dirname(path), { recursive: true });
+          await writeFile(path, content);
+        }
+      }
+
+      let uploadAuth: string | null | undefined = "unset";
+      const uploadFetch = (async (
+        url: string | URL,
+        init: RequestInit = {},
+      ) => {
+        const headers = new Headers(init.headers);
+        uploadAuth = headers.get("Authorization");
+        expect(String(url)).toBe(fixture.upload?.url);
+        expect((init.method ?? "GET").toUpperCase()).toBe("PUT");
+        expect(headers.get("Content-Type")).toBe(fixture.upload?.content_type);
+        const bytes = new Uint8Array(
+          await new Response(init.body).arrayBuffer(),
+        );
+        const files = Object.fromEntries(
+          Object.entries(unzipSync(bytes)).map(([path, value]) => [
+            path,
+            new TextDecoder().decode(value),
+          ]),
+        );
+        expect(files).toEqual(fixture.upload?.zip_files ?? {});
+        return new Response("", { status: 200 });
+      }) as unknown as typeof fetch;
+
+      const client = new UltralyticsClient({
+        apiKey: KEY,
+        baseUrl: BASE,
+        fetchImpl: replayFetch(fixture.api),
+        uploadFetchImpl: uploadFetch,
+      });
+
+      const result = await datasetUploadFolder(client, {
+        dataset: args.dataset as string,
+        folderPath: args.folder_path as string,
+        targetSplit: args.targetSplit as string | undefined,
+      });
+
+      expectMatch(result, expected);
       expect(uploadAuth).toBeNull();
     } finally {
       await rm(tmp, { recursive: true, force: true });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -83,4 +83,12 @@ test("server registers all available tools over the protocol", async () => {
     "dataset",
     "file_path",
   ]);
+
+  const datasetUploadFolder = tools.find(
+    (tool) => tool.name === "dataset_upload_folder",
+  );
+  expect(datasetUploadFolder?.inputSchema?.required).toEqual([
+    "dataset",
+    "folder_path",
+  ]);
 });

--- a/tests/tools/datasets.test.ts
+++ b/tests/tools/datasets.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
@@ -13,6 +13,7 @@ import {
   datasetsIngest,
   datasetsList,
   datasetUploadFile,
+  datasetUploadFolder,
   datasetVersionCreate,
 } from "../../src/tools/datasets.js";
 import { BASE, jsonResponse, KEY, routeClient } from "../helpers.js";
@@ -324,6 +325,123 @@ describe("datasetVersionCreate", () => {
       version: 4,
       downloadUrl: "https://cdn.example.com/data-v4.ndjson",
     });
+  });
+});
+
+describe("datasetUploadFolder", () => {
+  test("orchestrates folder zip upload and ingest", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ul-dataset-folder-"));
+    await writeFile(join(dir, "bird.jpg"), "jpg");
+    await writeFile(join(dir, "bird.png"), "png");
+    await writeFile(join(dir, ".DS_Store"), "junk");
+    await writeFile(join(dir, "notes.txt"), "ignore");
+    const nested = join(dir, "nested");
+    await mkdir(nested);
+    await writeFile(join(nested, "bird.webp"), "webp");
+
+    const uploadCalls: { url: string; init: RequestInit }[] = [];
+    const uploadImpl = (async (url: string | URL, init: RequestInit = {}) => {
+      uploadCalls.push({ url: String(url), init });
+      return new Response("", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const apiCalls: { url: string; method: string; body: unknown }[] = [];
+    const apiImpl = (async (url: string | URL, init: RequestInit = {}) => {
+      let body: unknown;
+      if (typeof init.body === "string") {
+        body = JSON.parse(init.body);
+      }
+      apiCalls.push({
+        url: String(url),
+        method: (init.method ?? "GET").toUpperCase(),
+        body,
+      });
+      const parsed = new URL(String(url));
+      if (parsed.pathname === "/api/datasets") {
+        return jsonResponse({
+          datasets: [{ _id: "d".repeat(24), slug: "data", username: "user" }],
+        });
+      }
+      if (parsed.pathname === "/api/upload/signed-url") {
+        return jsonResponse({
+          sessionId: "session_123",
+          uploadUrl: "https://signed.example/upload",
+        });
+      }
+      if (parsed.pathname === "/api/upload/complete") {
+        return jsonResponse({ ok: true });
+      }
+      return jsonResponse({
+        jobId: "job_123",
+        datasetId: "d".repeat(24),
+        status: "queued",
+      });
+    }) as unknown as typeof fetch;
+
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: apiImpl,
+      uploadFetchImpl: uploadImpl,
+    });
+
+    const result = await datasetUploadFolder(client, {
+      dataset: "user/data",
+      folderPath: dir,
+      targetSplit: "train",
+    });
+
+    expect(apiCalls[1]).toMatchObject({
+      url: `${BASE}/upload/signed-url`,
+      method: "POST",
+      body: {
+        assetType: "datasets",
+        assetId: "d".repeat(24),
+        contentType: "application/zip",
+      },
+    });
+    expect(uploadCalls[0].url).toBe("https://signed.example/upload");
+    expect(
+      (uploadCalls[0].init.headers as Record<string, string>).Authorization,
+    ).toBeUndefined();
+    expect(apiCalls[2]).toEqual({
+      url: `${BASE}/upload/complete`,
+      method: "POST",
+      body: { sessionId: "session_123" },
+    });
+    expect(apiCalls[3]).toEqual({
+      url: `${BASE}/datasets/ingest`,
+      method: "POST",
+      body: {
+        datasetId: "d".repeat(24),
+        sessionId: "session_123",
+        targetSplit: "train",
+      },
+    });
+    expect(result.summary).toContain("Zipped 3 image(s)");
+  });
+
+  test("rejects targetSplit when folder already has split dirs", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ul-dataset-folder-"));
+    const trainDir = join(dir, "train");
+    await mkdir(trainDir);
+    await writeFile(join(trainDir, "bird.jpg"), "jpg");
+
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: (async () => {
+        throw new Error("network must not be called");
+      }) as unknown as typeof fetch,
+    });
+
+    await expect(
+      datasetUploadFolder(client, {
+        dataset: "d".repeat(24),
+        folderPath: dir,
+        targetSplit: "train",
+      }),
+    ).rejects.toThrow(/Folder has split directories/);
   });
 });
 


### PR DESCRIPTION
## Summary
Add MCP support for uploading local image folders to Ultralytics Platform datasets.

## Motivation
This adds next dataset ingestion workflow while keeping folder upload isolated and easy to review on its own.

## Key Changes
- add `dataset_upload_folder` tool wiring, recursive image discovery, zip creation, and signed upload flow
- reject ambiguous `targetSplit` usage when folder already contains split directories
- add tests, parity fixture, README sync, and `fflate` dependency for zip generation
