### PR TITLE
feat: add explore search tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@ MCP server for the [Ultralytics Platform](https://platform.ultralytics.com).
 
 > Independent community project. Not affiliated with or endorsed by Ultralytics.
 
-Current milestone: read, monitor, predict, export, and initial project and
-dataset lifecycle tools are available. Additional resource-management tools
-land incrementally from here.
+Current milestone: read, explore, monitor, predict, export, and initial
+project and dataset lifecycle tools are available. Additional
+resource-management tools land incrementally from here.
 
-## Tools (24)
+## Tools (26)
 
 | Tool | Description |
 | --- | --- |
 | `projects_list` / `projects_get` | Browse projects |
 | `projects_create` / `projects_delete` | Create / soft-delete projects |
+| `explore_projects` / `explore_datasets` | Search public projects and datasets on Ultralytics Explore |
 | `datasets_list` / `datasets_get` / `datasets_create` / `datasets_delete` / `dataset_images_list` / `dataset_ingest` / `dataset_upload_file` / `dataset_upload_folder` | Browse / create / soft-delete datasets, inspect images, start remote ingest jobs, and upload archive files or folders |
 | `models_list` / `models_get` | Browse trained models and metrics |
 | `training_monitor` | Status, progress, and latest metrics |

--- a/fixtures/parity/explore_datasets.json
+++ b/fixtures/parity/explore_datasets.json
@@ -1,0 +1,59 @@
+{
+  "tool": "explore_datasets",
+  "args": {
+    "q": "bird",
+    "sort": "stars",
+    "offset": 20,
+    "task": ["detect", "segment"]
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/explore/search",
+      "query": {
+        "type": "datasets",
+        "q": "bird",
+        "sort": "stars",
+        "offset": "20",
+        "task": "detect,segment"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "datasets": [
+            {
+              "_id": "dddddddddddddddddddddddd",
+              "name": "Birds",
+              "slug": "birds",
+              "username": "user",
+              "task": "detect",
+              "imageCount": 65,
+              "classCount": 3,
+              "starCount": 7,
+              "ignored": "omit"
+            }
+          ],
+          "hasMore": true
+        }
+      }
+    }
+  ],
+  "expected": {
+    "summary": "Search 'bird': 1 dataset(s) (more available)",
+    "data": {
+      "datasets": [
+        {
+          "id": "dddddddddddddddddddddddd",
+          "name": "Birds",
+          "slug": "birds",
+          "username": "user",
+          "task": "detect",
+          "imageCount": 65,
+          "classCount": 3,
+          "starCount": 7
+        }
+      ],
+      "hasMore": true
+    }
+  }
+}

--- a/fixtures/parity/explore_projects.json
+++ b/fixtures/parity/explore_projects.json
@@ -1,0 +1,55 @@
+{
+  "tool": "explore_projects",
+  "args": {
+    "q": "road",
+    "sort": "name-asc",
+    "offset": 0
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/explore/search",
+      "query": {
+        "type": "projects",
+        "q": "road",
+        "sort": "name-asc",
+        "offset": "0"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "projects": [
+            {
+              "_id": "pppppppppppppppppppppppp",
+              "name": "Road Safety",
+              "slug": "road-safety",
+              "username": "user",
+              "visibility": "public",
+              "modelCount": 12,
+              "starCount": 99,
+              "ignored": "omit"
+            }
+          ],
+          "hasMore": false
+        }
+      }
+    }
+  ],
+  "expected": {
+    "summary": "Search 'road': 1 project(s)",
+    "data": {
+      "projects": [
+        {
+          "id": "pppppppppppppppppppppppp",
+          "name": "Road Safety",
+          "slug": "road-safety",
+          "username": "user",
+          "visibility": "public",
+          "modelCount": 12,
+          "starCount": 99
+        }
+      ],
+      "hasMore": false
+    }
+  }
+}

--- a/src/tools/datasets.ts
+++ b/src/tools/datasets.ts
@@ -8,6 +8,7 @@ import { zipSync } from "fflate";
 import type { UltralyticsClient } from "../client.js";
 import { resolveDataset } from "../resolve.js";
 import type { NormalizedToolResult } from "../tool-result.js";
+import { exploreSearch, validateExploreTasks } from "./explore.js";
 import { asRecord, listField, pyCount, pyField } from "./shared.js";
 
 const DATASET_TASKS = new Set([
@@ -253,6 +254,43 @@ export async function datasetsList(
     visibility: dataset.visibility ?? null,
   }));
   return { summary: `${items.length} dataset(s).`, data: items };
+}
+
+export interface ExploreDatasetsOptions {
+  q: string;
+  sort?: string;
+  offset?: number;
+  task?: string[];
+}
+
+/** Search public datasets on Explore. */
+export async function exploreDatasets(
+  client: UltralyticsClient,
+  options: ExploreDatasetsOptions,
+): Promise<NormalizedToolResult> {
+  const data = await exploreSearch(client, "datasets", options.q, {
+    sort: options.sort,
+    offset: options.offset,
+    task: validateExploreTasks(options.task),
+  });
+  const items = listField(data, "datasets").map((dataset) => ({
+    id: dataset._id ?? null,
+    name: dataset.name ?? null,
+    slug: dataset.slug ?? null,
+    username: dataset.username ?? null,
+    task: dataset.task ?? null,
+    imageCount: dataset.imageCount ?? null,
+    classCount: dataset.classCount ?? null,
+    starCount: dataset.starCount ?? null,
+  }));
+  const hasMore = Boolean(data.hasMore);
+  return {
+    summary: `Search '${options.q.trim()}': ${items.length} dataset(s)${hasMore ? " (more available)" : ""}`,
+    data: {
+      datasets: items,
+      hasMore,
+    },
+  };
 }
 
 /** Get one dataset by id, slug, username/slug, or dataset ul:// URI. */

--- a/src/tools/explore.ts
+++ b/src/tools/explore.ts
@@ -1,0 +1,79 @@
+import type { UltralyticsClient } from "../client.js";
+import { asRecord } from "./shared.js";
+
+const EXPLORE_SORTS = new Set([
+  "newest",
+  "stars",
+  "oldest",
+  "name-asc",
+  "name-desc",
+  "count-desc",
+  "count-asc",
+]);
+
+const DATASET_TASKS = new Set([
+  "detect",
+  "segment",
+  "semantic",
+  "classify",
+  "pose",
+  "obb",
+]);
+
+export function validateExploreQuery(
+  q: string,
+  sort = "newest",
+  offset = 0,
+): void {
+  if (!q.trim()) {
+    throw new Error("q is required: a search query");
+  }
+  if (!EXPLORE_SORTS.has(sort)) {
+    const allowed = Array.from(EXPLORE_SORTS).sort().join(", ");
+    throw new Error(`Unsupported sort '${sort}'. Expected one of: ${allowed}.`);
+  }
+  if (offset < 0) {
+    throw new Error("`offset` must be greater than or equal to 0.");
+  }
+}
+
+export function validateExploreTasks(task?: string[]): string | undefined {
+  if (!task || task.length === 0) {
+    return undefined;
+  }
+  for (const item of task) {
+    if (!DATASET_TASKS.has(item)) {
+      const allowed = Array.from(DATASET_TASKS).sort().join(", ");
+      throw new Error(
+        `Unsupported dataset task '${item}'. Expected one of: ${allowed}.`,
+      );
+    }
+  }
+  return task.join(",");
+}
+
+export async function exploreSearch(
+  client: UltralyticsClient,
+  type: "datasets" | "projects",
+  q: string,
+  options: {
+    sort?: string;
+    offset?: number;
+    task?: string;
+  } = {},
+): Promise<Record<string, unknown>> {
+  const sort = options.sort ?? "newest";
+  const offset = options.offset ?? 0;
+  validateExploreQuery(q, sort, offset);
+
+  const params: Record<string, unknown> = {
+    type,
+    q: q.trim(),
+    sort,
+    offset,
+  };
+  if (options.task !== undefined) {
+    params.task = options.task;
+  }
+  return asRecord(await client.get("/explore/search", params));
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -22,6 +22,7 @@ import {
   datasetUploadFile,
   datasetUploadFolder,
   datasetVersionCreate,
+  exploreDatasets,
 } from "./datasets.js";
 import { modelDownload } from "./downloads.js";
 import { exportCreate, exportStatus, exportsList } from "./exports.js";
@@ -29,6 +30,7 @@ import { gpuAvailability } from "./gpu.js";
 import { modelsGet, modelsList } from "./models.js";
 import { modelPredict } from "./predict.js";
 import {
+  exploreProjects,
   projectsCreate,
   projectsDelete,
   projectsGet,
@@ -47,6 +49,7 @@ export {
   datasetUploadFile,
   datasetUploadFolder,
   datasetVersionCreate,
+  exploreDatasets,
 } from "./datasets.js";
 export { modelDownload } from "./downloads.js";
 export { exportCreate, exportStatus, exportsList } from "./exports.js";
@@ -54,6 +57,7 @@ export { gpuAvailability } from "./gpu.js";
 export { modelsGet, modelsList } from "./models.js";
 export { modelPredict } from "./predict.js";
 export {
+  exploreProjects,
   projectsCreate,
   projectsDelete,
   projectsGet,
@@ -65,14 +69,16 @@ export { trainingMonitor, trainingStart } from "./training.js";
 export const READ_TOOL_NAMES = [
   "projects_list",
   "projects_get",
+  "explore_projects",
   "projects_create",
   "projects_delete",
   "datasets_list",
   "datasets_get",
-  "datasets_create",
+  "explore_datasets",
   "dataset_images_list",
   "dataset_export",
   "dataset_version_create",
+  "datasets_create",
   "datasets_delete",
   "dataset_ingest",
   "dataset_upload_file",
@@ -107,6 +113,20 @@ export function registerReadTools(
     },
     async ({ project }) =>
       toMcpTextResult(await projectsGet(getClient(), project)),
+  );
+
+  server.registerTool(
+    "explore_projects",
+    {
+      description: "Search public projects on Ultralytics Explore.",
+      inputSchema: {
+        q: z.string(),
+        sort: z.string().optional(),
+        offset: z.number().int().optional(),
+      },
+    },
+    async ({ q, sort, offset }) =>
+      toMcpTextResult(await exploreProjects(getClient(), { q, sort, offset })),
   );
 
   server.registerTool(
@@ -155,6 +175,23 @@ export function registerReadTools(
     },
     async ({ dataset }) =>
       toMcpTextResult(await datasetsGet(getClient(), dataset)),
+  );
+
+  server.registerTool(
+    "explore_datasets",
+    {
+      description: "Search public datasets on Ultralytics Explore.",
+      inputSchema: {
+        q: z.string(),
+        sort: z.string().optional(),
+        offset: z.number().int().optional(),
+        task: z.array(z.string()).optional(),
+      },
+    },
+    async ({ q, sort, offset, task }) =>
+      toMcpTextResult(
+        await exploreDatasets(getClient(), { q, sort, offset, task }),
+      ),
   );
 
   server.registerTool(

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -3,6 +3,7 @@
 import type { UltralyticsClient } from "../client.js";
 import { resolveProject } from "../resolve.js";
 import type { NormalizedToolResult } from "../tool-result.js";
+import { exploreSearch } from "./explore.js";
 import { asRecord, listField, pyCount, pyField } from "./shared.js";
 
 function resourceId(item: Record<string, unknown>, fallback?: string): string {
@@ -28,6 +29,40 @@ export async function projectsList(
     modelCount: project.modelCount ?? null,
   }));
   return { summary: `${items.length} project(s).`, data: items };
+}
+
+export interface ExploreProjectsOptions {
+  q: string;
+  sort?: string;
+  offset?: number;
+}
+
+/** Search public projects on Explore. */
+export async function exploreProjects(
+  client: UltralyticsClient,
+  options: ExploreProjectsOptions,
+): Promise<NormalizedToolResult> {
+  const data = await exploreSearch(client, "projects", options.q, {
+    sort: options.sort,
+    offset: options.offset,
+  });
+  const items = listField(data, "projects").map((project) => ({
+    id: project._id ?? null,
+    name: project.name ?? null,
+    slug: project.slug ?? null,
+    username: project.username ?? null,
+    visibility: project.visibility ?? null,
+    modelCount: project.modelCount ?? null,
+    starCount: project.starCount ?? null,
+  }));
+  const hasMore = Boolean(data.hasMore);
+  return {
+    summary: `Search '${options.q.trim()}': ${items.length} project(s)${hasMore ? " (more available)" : ""}`,
+    data: {
+      projects: items,
+      hasMore,
+    },
+  };
 }
 
 /** Get one project by id, slug, username/slug, or project ul:// URI. */

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -19,6 +19,8 @@ import {
   datasetUploadFile,
   datasetUploadFolder,
   datasetVersionCreate,
+  exploreDatasets,
+  exploreProjects,
   modelDownload,
   modelsGet,
   projectsCreate,
@@ -191,6 +193,19 @@ const TOOL_RUNNERS: Record<
       dataset: args.dataset as string,
       description: args.description as string | undefined,
     }),
+  explore_projects: (client, args) =>
+    exploreProjects(client, {
+      q: args.q as string,
+      sort: args.sort as string | undefined,
+      offset: args.offset as number | undefined,
+    }),
+  explore_datasets: (client, args) =>
+    exploreDatasets(client, {
+      q: args.q as string,
+      sort: args.sort as string | undefined,
+      offset: args.offset as number | undefined,
+      task: args.task as string[] | undefined,
+    }),
   dataset_upload_folder: (client, args) =>
     datasetUploadFolder(client, {
       dataset: args.dataset as string,
@@ -257,6 +272,8 @@ describe("parity fixtures", () => {
         "dataset_export.json",
         "dataset_images_list.json",
         "dataset_ingest.json",
+        "explore_datasets.json",
+        "explore_projects.json",
         "dataset_version_create.json",
         "dataset_upload_file.json",
         "dataset_upload_folder.json",

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -41,6 +41,11 @@ test("server registers all available tools over the protocol", async () => {
   expect(projectsGet?.inputSchema?.type).toBe("object");
   expect(projectsGet?.inputSchema?.required).toEqual(["project"]);
 
+  const exploreProjects = tools.find(
+    (tool) => tool.name === "explore_projects",
+  );
+  expect(exploreProjects?.inputSchema?.required).toEqual(["q"]);
+
   const projectsCreate = tools.find((tool) => tool.name === "projects_create");
   expect(projectsCreate?.inputSchema?.required).toEqual(["name"]);
 
@@ -61,6 +66,11 @@ test("server registers all available tools over the protocol", async () => {
     (tool) => tool.name === "dataset_images_list",
   );
   expect(datasetImagesList?.inputSchema?.required).toEqual(["dataset"]);
+
+  const exploreDatasets = tools.find(
+    (tool) => tool.name === "explore_datasets",
+  );
+  expect(exploreDatasets?.inputSchema?.required).toEqual(["q"]);
 
   const datasetExport = tools.find((tool) => tool.name === "dataset_export");
   expect(datasetExport?.inputSchema?.required).toEqual(["dataset"]);

--- a/tests/tools/datasets.test.ts
+++ b/tests/tools/datasets.test.ts
@@ -15,6 +15,7 @@ import {
   datasetUploadFile,
   datasetUploadFolder,
   datasetVersionCreate,
+  exploreDatasets,
 } from "../../src/tools/datasets.js";
 import { BASE, jsonResponse, KEY, routeClient } from "../helpers.js";
 
@@ -76,6 +77,87 @@ describe("datasetsList", () => {
         visibility: "private",
       },
     ]);
+  });
+});
+
+describe("exploreDatasets", () => {
+  test("builds query, validates task filter, and trims results", async () => {
+    const { client, calls } = captureClient((url) => {
+      const parsed = new URL(url);
+      if (parsed.pathname === "/api/explore/search") {
+        return jsonResponse({
+          datasets: [
+            {
+              _id: "d".repeat(24),
+              name: "Birds",
+              slug: "birds",
+              username: "user",
+              task: "detect",
+              imageCount: 65,
+              classCount: 3,
+              starCount: 7,
+              extra: "omit",
+            },
+          ],
+          hasMore: true,
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const result = await exploreDatasets(client, {
+      q: "bird",
+      sort: "stars",
+      offset: 20,
+      task: ["detect", "segment"],
+    });
+
+    expect(calls[0]).toEqual({
+      url:
+        `${BASE}/explore/search` +
+        "?type=datasets&q=bird&sort=stars&offset=20&task=detect%2Csegment",
+      method: "GET",
+      body: undefined,
+    });
+    expect(result.summary).toBe("Search 'bird': 1 dataset(s) (more available)");
+    expect(result.data).toEqual({
+      datasets: [
+        {
+          id: "d".repeat(24),
+          name: "Birds",
+          slug: "birds",
+          username: "user",
+          task: "detect",
+          imageCount: 65,
+          classCount: 3,
+          starCount: 7,
+        },
+      ],
+      hasMore: true,
+    });
+  });
+
+  test("validates q, sort, offset, and task before network", async () => {
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: (async () => {
+        throw new Error("network must not be called");
+      }) as typeof fetch,
+    });
+
+    await expect(exploreDatasets(client, { q: "" })).rejects.toThrow(
+      /q is required/,
+    );
+    await expect(
+      exploreDatasets(client, { q: "bird", sort: "popular" }),
+    ).rejects.toThrow(/Unsupported sort/);
+    await expect(
+      exploreDatasets(client, { q: "bird", offset: -1 }),
+    ).rejects.toThrow(/offset/);
+    await expect(
+      exploreDatasets(client, { q: "bird", task: ["detect", "bad"] }),
+    ).rejects.toThrow(/Unsupported dataset task/);
   });
 });
 

--- a/tests/tools/projects.test.ts
+++ b/tests/tools/projects.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import { UltralyticsClient } from "../../src/client.js";
 import {
+  exploreProjects,
   projectsCreate,
   projectsDelete,
   projectsGet,
@@ -83,6 +84,79 @@ describe("projectsList", () => {
     const result = await projectsList(client, "alice");
     expect(result.summary).toBe("0 project(s).");
     expect(calls[0].params.get("username")).toBe("alice");
+  });
+});
+
+describe("exploreProjects", () => {
+  test("builds query and trims results", async () => {
+    const { client, calls } = captureClient((url) => {
+      const parsed = new URL(url);
+      if (parsed.pathname === "/api/explore/search") {
+        return jsonResponse({
+          projects: [
+            {
+              _id: "p".repeat(24),
+              name: "Road Safety",
+              slug: "road-safety",
+              username: "user",
+              visibility: "public",
+              modelCount: 12,
+              starCount: 99,
+              extra: "omit",
+            },
+          ],
+          hasMore: false,
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const result = await exploreProjects(client, {
+      q: "road",
+      sort: "name-asc",
+      offset: 0,
+    });
+
+    expect(calls[0]).toEqual({
+      url: `${BASE}/explore/search?type=projects&q=road&sort=name-asc&offset=0`,
+      method: "GET",
+      body: undefined,
+    });
+    expect(result.summary).toBe("Search 'road': 1 project(s)");
+    expect(result.data).toEqual({
+      projects: [
+        {
+          id: "p".repeat(24),
+          name: "Road Safety",
+          slug: "road-safety",
+          username: "user",
+          visibility: "public",
+          modelCount: 12,
+          starCount: 99,
+        },
+      ],
+      hasMore: false,
+    });
+  });
+
+  test("validates q, sort, and offset before network", async () => {
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: (async () => {
+        throw new Error("network must not be called");
+      }) as typeof fetch,
+    });
+
+    await expect(exploreProjects(client, { q: "" })).rejects.toThrow(
+      /q is required/,
+    );
+    await expect(
+      exploreProjects(client, { q: "road", sort: "popular" }),
+    ).rejects.toThrow(/Unsupported sort/);
+    await expect(
+      exploreProjects(client, { q: "road", offset: -1 }),
+    ).rejects.toThrow(/offset/);
   });
 });
 


### PR DESCRIPTION
## Summary
Add MCP support for searching public projects and datasets on Ultralytics Explore.

## Motivation
This adds next discovery-focused read tools while keeping public explore search isolated and easy to review on its own.

## Key Changes
- add `explore_projects` and `explore_datasets` tool wiring with shared query validation
- support search sorting, paging, and dataset task filters with normalized result output
- add tests, parity fixtures, and README sync for both explore tools
