### PR TITLE
feat: add dataset upload video tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 MCP server for the [Ultralytics Platform](https://platform.ultralytics.com).
 
+> [!IMPORTANT]
 > Independent community project. Not affiliated with or endorsed by Ultralytics.
 
 Current milestone: read, explore, monitor, predict, export, and extended

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ MCP server for the [Ultralytics Platform](https://platform.ultralytics.com).
 
 > Independent community project. Not affiliated with or endorsed by Ultralytics.
 
-Current milestone: read, explore, monitor, predict, export, and initial
+Current milestone: read, explore, monitor, predict, export, and extended
 project and dataset lifecycle tools are available. Additional
 resource-management tools land incrementally from here.
 
-## Tools (26)
+## Tools (27)
 
 | Tool | Description |
 | --- | --- |
 | `projects_list` / `projects_get` | Browse projects |
 | `projects_create` / `projects_delete` | Create / soft-delete projects |
 | `explore_projects` / `explore_datasets` | Search public projects and datasets on Ultralytics Explore |
-| `datasets_list` / `datasets_get` / `datasets_create` / `datasets_delete` / `dataset_images_list` / `dataset_ingest` / `dataset_upload_file` / `dataset_upload_folder` | Browse / create / soft-delete datasets, inspect images, start remote ingest jobs, and upload archive files or folders |
+| `datasets_list` / `datasets_get` / `datasets_create` / `datasets_delete` / `dataset_images_list` / `dataset_ingest` / `dataset_upload_file` / `dataset_upload_folder` / `dataset_upload_video` | Browse / create / soft-delete datasets, inspect images, start remote ingest jobs, and upload archive files, folders, or videos |
 | `models_list` / `models_get` | Browse trained models and metrics |
 | `training_monitor` | Status, progress, and latest metrics |
 | `model_predict` | Run inference on an image URL or base64 source |

--- a/fixtures/parity/dataset_upload_video.json
+++ b/fixtures/parity/dataset_upload_video.json
@@ -1,0 +1,106 @@
+{
+  "tool": "dataset_upload_video",
+  "args": {
+    "dataset": "user/data",
+    "video_path": "__TMP__/birds.mp4",
+    "fps": 1,
+    "max_frames": 100,
+    "targetSplit": "train"
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/datasets",
+      "query": {
+        "slug": "data",
+        "username": "user"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "datasets": [
+            {
+              "_id": "dddddddddddddddddddddddd",
+              "slug": "data",
+              "username": "user"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/upload/signed-url",
+      "json": {
+        "assetType": "datasets",
+        "assetId": "dddddddddddddddddddddddd",
+        "filename": "birds.zip",
+        "contentType": "application/zip",
+        "totalBytes": "__ANY_NUMBER__"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "sessionId": "session_123",
+          "uploadUrl": "https://signed.example/upload"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/upload/complete",
+      "json": {
+        "sessionId": "session_123"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "ok": true
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/datasets/ingest",
+      "json": {
+        "datasetId": "dddddddddddddddddddddddd",
+        "sessionId": "session_123",
+        "targetSplit": "train"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "jobId": "job_123",
+          "datasetId": "dddddddddddddddddddddddd",
+          "status": "queued"
+        }
+      }
+    }
+  ],
+  "upload": {
+    "url": "https://signed.example/upload",
+    "content_type": "application/zip",
+    "zip_files": {
+      "frame_000001.jpg": "jpg",
+      "frame_000002.jpg": "jpg",
+      "frame_000003.jpg": "jpg"
+    }
+  },
+  "expected": {
+    "summary": "Extracted 3 frame(s) at ~0.5 fps from __TMP__/birds.mp4; started ingest job job_123 for dataset dddddddddddddddddddddddd.",
+    "data": {
+      "datasetId": "dddddddddddddddddddddddd",
+      "frameCount": 3,
+      "fps": 1,
+      "maxFrames": 100,
+      "filename": "birds.zip",
+      "bytes": "__ANY_NUMBER__",
+      "sessionId": "session_123",
+      "ingest": {
+        "jobId": "job_123",
+        "datasetId": "dddddddddddddddddddddddd",
+        "status": "queued"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "fflate": "^0.8.2",
+        "fflate": "^0.8.3",
         "zod": "^4.4.3"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "fflate": "^0.8.2",
+    "fflate": "^0.8.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/tools/datasets.ts
+++ b/src/tools/datasets.ts
@@ -1,7 +1,10 @@
 /** Read-only dataset tools. */
 
-import { readdir, readFile, stat } from "node:fs/promises";
-import { basename, relative, resolve } from "node:path";
+import { execFile as execFileCb } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
+import { basename, join, relative, resolve } from "node:path";
+import { promisify } from "node:util";
 
 import { zipSync } from "fflate";
 
@@ -31,6 +34,14 @@ const IMAGE_SUFFIXES = new Set([
   ".tif",
   ".tiff",
 ]);
+const VIDEO_SUFFIXES = new Set([
+  ".mp4",
+  ".webm",
+  ".mov",
+  ".mkv",
+  ".m4v",
+  ".avi",
+]);
 const UPLOAD_TYPES: Array<[suffix: string, contentType: string]> = [
   [".tar.gz", "application/gzip"],
   [".zip", "application/zip"],
@@ -38,6 +49,7 @@ const UPLOAD_TYPES: Array<[suffix: string, contentType: string]> = [
   [".tgz", "application/gzip"],
   [".ndjson", "application/x-ndjson"],
 ];
+const execFile = promisify(execFileCb);
 
 function resourceId(item: Record<string, unknown>, fallback?: string): string {
   const value = item._id ?? item.id ?? item.projectId ?? item.datasetId;
@@ -51,6 +63,53 @@ function validateTargetSplit(targetSplit?: string): void {
       `Unsupported targetSplit '${targetSplit}'. Expected one of: ${allowed}.`,
     );
   }
+}
+
+function findToolOnPath(name: string): string | null {
+  const paths = process.env.PATH?.split(":") ?? [];
+  for (const base of paths) {
+    const candidate = resolve(base, name);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+async function probeVideoDuration(
+  videoPath: string,
+  ffprobePath: string,
+): Promise<number> {
+  const { stdout } = await execFile(ffprobePath, [
+    "-v",
+    "error",
+    "-show_entries",
+    "format=duration",
+    "-of",
+    "default=nokey=1:noprint_wrappers=1",
+    videoPath,
+  ]);
+  return Number.parseFloat(stdout.trim());
+}
+
+async function extractVideoFrames(options: {
+  videoPath: string;
+  outputDir: string;
+  ffmpegPath: string;
+  rate: number;
+  maxFrames: number;
+}): Promise<void> {
+  await execFile(options.ffmpegPath, [
+    "-i",
+    options.videoPath,
+    "-vf",
+    `fps=${options.rate}`,
+    "-frames:v",
+    String(options.maxFrames),
+    "-q:v",
+    "2",
+    join(options.outputDir, "frame_%06d.jpg"),
+  ]);
 }
 
 async function datasetUploadFileMeta(filePath: string): Promise<{
@@ -580,6 +639,119 @@ export async function datasetUploadFolder(
       ingest: upload.ingest,
     },
   };
+}
+
+export interface DatasetUploadVideoOptions {
+  dataset: string;
+  videoPath: string;
+  fps?: number;
+  maxFrames?: number;
+  targetSplit?: string;
+  _findTool?: (name: string) => string | null;
+  _probeDuration?: (videoPath: string, ffprobePath: string) => Promise<number>;
+  _extractFrames?: (options: {
+    videoPath: string;
+    outputDir: string;
+    ffmpegPath: string;
+    rate: number;
+    maxFrames: number;
+  }) => Promise<void>;
+}
+
+/** Upload local video by extracting JPEG frames, then start dataset ingest. */
+export async function datasetUploadVideo(
+  client: UltralyticsClient,
+  options: DatasetUploadVideoOptions,
+): Promise<NormalizedToolResult> {
+  validateTargetSplit(options.targetSplit);
+  if (!options.videoPath.trim()) {
+    throw new Error("`videoPath` is required.");
+  }
+  const fps = options.fps ?? 1;
+  const maxFrames = options.maxFrames ?? 100;
+  if (fps <= 0) {
+    throw new Error("`fps` must be greater than 0.");
+  }
+  if (maxFrames <= 0) {
+    throw new Error("`maxFrames` must be greater than 0.");
+  }
+
+  const resolvedVideo = resolve(options.videoPath);
+  const info = await stat(resolvedVideo).catch(() => null);
+  if (info === null) {
+    throw new Error(`Upload video does not exist: ${resolvedVideo}`);
+  }
+  if (!info.isFile()) {
+    throw new Error(`Upload path is not a file: ${resolvedVideo}`);
+  }
+  const lower = basename(resolvedVideo).toLowerCase();
+  if (!Array.from(VIDEO_SUFFIXES).some((suffix) => lower.endsWith(suffix))) {
+    throw new Error(
+      `Unsupported video file type. Expected one of: ${Array.from(VIDEO_SUFFIXES).sort().join(", ")}.`,
+    );
+  }
+
+  const findTool = options._findTool ?? findToolOnPath;
+  const ffmpegPath = findTool("ffmpeg");
+  const ffprobePath = findTool("ffprobe");
+  if (!ffmpegPath || !ffprobePath) {
+    throw new Error(
+      "ffmpeg/ffprobe not found on PATH. Install ffmpeg, or extract frames yourself (ffmpeg -i video.mp4 -vf fps=1 frames/%06d.jpg) and use dataset_upload_folder.",
+    );
+  }
+
+  let rate = fps;
+  let usedProbeFallback = false;
+  const probe = options._probeDuration ?? probeVideoDuration;
+  try {
+    const duration = await probe(resolvedVideo, ffprobePath);
+    if (duration > 0) {
+      rate = Math.min(fps, maxFrames / duration);
+    }
+  } catch {
+    usedProbeFallback = true;
+    rate = fps;
+  }
+
+  const extract = options._extractFrames ?? extractVideoFrames;
+  const outputDir = await mkdtemp(join(process.cwd(), ".ultralytics-video-"));
+  try {
+    await extract({
+      videoPath: resolvedVideo,
+      outputDir,
+      ffmpegPath,
+      rate,
+      maxFrames,
+    });
+    const folder = await datasetFolderImages(outputDir);
+    const content = await buildDatasetFolderZip(folder.files);
+    const datasetId = await resolveDataset(client, options.dataset);
+    const filename = `${basename(resolvedVideo).replace(/\.[^.]+$/, "")}.zip`;
+    const upload = await uploadDatasetContent(client, {
+      datasetId,
+      filename,
+      contentType: "application/zip",
+      totalBytes: content.byteLength,
+      content,
+      targetSplit: options.targetSplit,
+    });
+    const jobId = upload.ingest.jobId ?? upload.ingest.id ?? "None";
+    return {
+      summary: `Extracted ${folder.files.length} frame(s) at ~${Number(rate.toFixed(4))} fps from ${resolvedVideo}; started ingest job ${String(jobId)} for dataset ${datasetId}.${usedProbeFallback ? " probe fallback" : ""}`,
+      data: {
+        datasetId,
+        frameCount: folder.files.length,
+        fps,
+        maxFrames,
+        filename,
+        bytes: content.byteLength,
+        sessionId: upload.sessionId,
+        ingest: upload.ingest,
+      },
+    };
+  } finally {
+    await rm(outputDir, { recursive: true, force: true });
+  }
 }
 
 export interface DatasetExportOptions {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -21,6 +21,7 @@ import {
   datasetsList,
   datasetUploadFile,
   datasetUploadFolder,
+  datasetUploadVideo,
   datasetVersionCreate,
   exploreDatasets,
 } from "./datasets.js";
@@ -48,6 +49,7 @@ export {
   datasetsList,
   datasetUploadFile,
   datasetUploadFolder,
+  datasetUploadVideo,
   datasetVersionCreate,
   exploreDatasets,
 } from "./datasets.js";
@@ -83,6 +85,7 @@ export const READ_TOOL_NAMES = [
   "dataset_ingest",
   "dataset_upload_file",
   "dataset_upload_folder",
+  "dataset_upload_video",
   "models_list",
   "models_get",
   "gpu_availability",
@@ -351,6 +354,31 @@ export function registerReadTools(
         await datasetUploadFolder(getClient(), {
           dataset,
           folderPath: folder_path,
+          targetSplit,
+        }),
+      ),
+  );
+
+  server.registerTool(
+    "dataset_upload_video",
+    {
+      description:
+        "Upload a local video by extracting JPEG frames with ffmpeg, then start dataset ingest for an existing dataset.",
+      inputSchema: {
+        dataset: z.string(),
+        video_path: z.string(),
+        fps: z.number().optional(),
+        max_frames: z.number().int().optional(),
+        targetSplit: z.string().optional(),
+      },
+    },
+    async ({ dataset, video_path, fps, max_frames, targetSplit }) =>
+      toMcpTextResult(
+        await datasetUploadVideo(getClient(), {
+          dataset,
+          videoPath: video_path,
+          fps,
+          maxFrames: max_frames,
           targetSplit,
         }),
       ),

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -18,6 +18,7 @@ import {
   datasetsIngest,
   datasetUploadFile,
   datasetUploadFolder,
+  datasetUploadVideo,
   datasetVersionCreate,
   exploreDatasets,
   exploreProjects,
@@ -72,6 +73,11 @@ type Fixture = z.infer<typeof fixtureSchema>;
 
 const BASE = "https://platform.ultralytics.com/api";
 const KEY = `ul_${"0".repeat(40)}`;
+const fixtureUploadVideoZipFiles = {
+  "frame_000001.jpg": "jpg",
+  "frame_000002.jpg": "jpg",
+  "frame_000003.jpg": "jpg",
+};
 
 function expectMatch(actual: unknown, expected: unknown): void {
   if (expected === "__ANY_NUMBER__") {
@@ -212,6 +218,29 @@ const TOOL_RUNNERS: Record<
       folderPath: args.folder_path as string,
       targetSplit: args.targetSplit as string | undefined,
     }),
+  dataset_upload_video: (client, args) =>
+    datasetUploadVideo(client, {
+      dataset: args.dataset as string,
+      videoPath: args.video_path as string,
+      fps: args.fps as number | undefined,
+      maxFrames: args.max_frames as number | undefined,
+      targetSplit: args.targetSplit as string | undefined,
+      _findTool: (name) => `/usr/bin/${name}`,
+      _probeDuration: async () => 200,
+      _extractFrames: async ({ outputDir, ffmpegPath, rate, maxFrames }) => {
+        expect(ffmpegPath).toBe("/usr/bin/ffmpeg");
+        expect(rate).toBe(0.5);
+        expect(maxFrames).toBe(100);
+        await mkdir(outputDir, { recursive: true });
+        for (const [path, content] of Object.entries(
+          fixtureUploadVideoZipFiles,
+        )) {
+          const filePath = join(outputDir, path);
+          await mkdir(dirname(filePath), { recursive: true });
+          await writeFile(filePath, content);
+        }
+      },
+    }),
   datasets_delete: (client, args) =>
     datasetsDelete(client, args.dataset as string),
   dataset_ingest: (client, args) =>
@@ -277,6 +306,7 @@ describe("parity fixtures", () => {
         "dataset_version_create.json",
         "dataset_upload_file.json",
         "dataset_upload_folder.json",
+        "dataset_upload_video.json",
         "models_get.json",
         "projects_create.json",
         "projects_delete.json",
@@ -300,7 +330,8 @@ describe("parity fixtures", () => {
     const fixture = fixtureSchema.parse(JSON.parse(raw));
     if (
       fixture.tool === "dataset_upload_file" ||
-      fixture.tool === "dataset_upload_folder"
+      fixture.tool === "dataset_upload_folder" ||
+      fixture.tool === "dataset_upload_video"
     ) {
       continue;
     }
@@ -469,6 +500,78 @@ describe("parity fixtures", () => {
         dataset: args.dataset as string,
         folderPath: args.folder_path as string,
         targetSplit: args.targetSplit as string | undefined,
+      });
+
+      expectMatch(result, expected);
+      expect(uploadAuth).toBeNull();
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("parity output: dataset_upload_video.json", async () => {
+    const raw = readFileSync(
+      join(fixtureDir, "dataset_upload_video.json"),
+      "utf8",
+    );
+    const fixture = fixtureSchema.parse(JSON.parse(raw));
+    const tmp = await mkdtemp(join(tmpdir(), "ul-mcp-"));
+    try {
+      const args = replaceTmp(fixture.args, tmp) as Record<string, unknown>;
+      const expected = replaceTmp(fixture.expected, tmp);
+      await writeFile(args.video_path as string, "video");
+
+      let uploadAuth: string | null | undefined = "unset";
+      const uploadFetch = (async (
+        url: string | URL,
+        init: RequestInit = {},
+      ) => {
+        const headers = new Headers(init.headers);
+        uploadAuth = headers.get("Authorization");
+        expect(String(url)).toBe(fixture.upload?.url);
+        expect((init.method ?? "GET").toUpperCase()).toBe("PUT");
+        expect(headers.get("Content-Type")).toBe(fixture.upload?.content_type);
+        const bytes = new Uint8Array(
+          await new Response(init.body).arrayBuffer(),
+        );
+        const files = Object.fromEntries(
+          Object.entries(unzipSync(bytes)).map(([path, value]) => [
+            path,
+            new TextDecoder().decode(value),
+          ]),
+        );
+        expect(files).toEqual(fixture.upload?.zip_files ?? {});
+        return new Response("", { status: 200 });
+      }) as unknown as typeof fetch;
+
+      const client = new UltralyticsClient({
+        apiKey: KEY,
+        baseUrl: BASE,
+        fetchImpl: replayFetch(fixture.api),
+        uploadFetchImpl: uploadFetch,
+      });
+
+      const result = await datasetUploadVideo(client, {
+        dataset: args.dataset as string,
+        videoPath: args.video_path as string,
+        fps: args.fps as number | undefined,
+        maxFrames: args.max_frames as number | undefined,
+        targetSplit: args.targetSplit as string | undefined,
+        _findTool: (name) => `/usr/bin/${name}`,
+        _probeDuration: async () => 200,
+        _extractFrames: async ({ outputDir, ffmpegPath, rate, maxFrames }) => {
+          expect(ffmpegPath).toBe("/usr/bin/ffmpeg");
+          expect(rate).toBe(0.5);
+          expect(maxFrames).toBe(100);
+          await mkdir(outputDir, { recursive: true });
+          for (const [path, content] of Object.entries(
+            fixtureUploadVideoZipFiles,
+          )) {
+            const filePath = join(outputDir, path);
+            await mkdir(dirname(filePath), { recursive: true });
+            await writeFile(filePath, content);
+          }
+        },
       });
 
       expectMatch(result, expected);

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -101,4 +101,12 @@ test("server registers all available tools over the protocol", async () => {
     "dataset",
     "folder_path",
   ]);
+
+  const datasetUploadVideo = tools.find(
+    (tool) => tool.name === "dataset_upload_video",
+  );
+  expect(datasetUploadVideo?.inputSchema?.required).toEqual([
+    "dataset",
+    "video_path",
+  ]);
 });

--- a/tests/tools/datasets.test.ts
+++ b/tests/tools/datasets.test.ts
@@ -14,6 +14,7 @@ import {
   datasetsList,
   datasetUploadFile,
   datasetUploadFolder,
+  datasetUploadVideo,
   datasetVersionCreate,
   exploreDatasets,
 } from "../../src/tools/datasets.js";
@@ -524,6 +525,206 @@ describe("datasetUploadFolder", () => {
         targetSplit: "train",
       }),
     ).rejects.toThrow(/Folder has split directories/);
+  });
+});
+
+describe("datasetUploadVideo", () => {
+  test("extracts frames and uploads them", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ul-video-"));
+    const videoPath = join(dir, "birds.mp4");
+    await writeFile(videoPath, "video");
+
+    const uploadCalls: { url: string; init: RequestInit }[] = [];
+    const uploadImpl = (async (url: string | URL, init: RequestInit = {}) => {
+      uploadCalls.push({ url: String(url), init });
+      return new Response("", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const apiCalls: { url: string; method: string; body: unknown }[] = [];
+    const apiImpl = (async (url: string | URL, init: RequestInit = {}) => {
+      let body: unknown;
+      if (typeof init.body === "string") {
+        body = JSON.parse(init.body);
+      }
+      apiCalls.push({
+        url: String(url),
+        method: (init.method ?? "GET").toUpperCase(),
+        body,
+      });
+      const parsed = new URL(String(url));
+      if (parsed.pathname === "/api/datasets") {
+        return jsonResponse({
+          datasets: [{ _id: "d".repeat(24), slug: "data", username: "user" }],
+        });
+      }
+      if (parsed.pathname === "/api/upload/signed-url") {
+        return jsonResponse({
+          sessionId: "session_123",
+          uploadUrl: "https://signed.example/upload",
+        });
+      }
+      if (parsed.pathname === "/api/upload/complete") {
+        return jsonResponse({ ok: true });
+      }
+      return jsonResponse({
+        jobId: "job_123",
+        datasetId: "d".repeat(24),
+        status: "queued",
+      });
+    }) as unknown as typeof fetch;
+
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: apiImpl,
+      uploadFetchImpl: uploadImpl,
+    });
+
+    const result = await datasetUploadVideo(client, {
+      dataset: "user/data",
+      videoPath,
+      targetSplit: "train",
+      _findTool: (name) => `/usr/bin/${name}`,
+      _probeDuration: async () => 200,
+      _extractFrames: async ({ outputDir, ffmpegPath, rate, maxFrames }) => {
+        expect(ffmpegPath).toBe("/usr/bin/ffmpeg");
+        expect(rate).toBe(0.5);
+        expect(maxFrames).toBe(100);
+        await writeFile(join(outputDir, "frame_000001.jpg"), "jpg");
+        await writeFile(join(outputDir, "frame_000002.jpg"), "jpg");
+        await writeFile(join(outputDir, "frame_000003.jpg"), "jpg");
+      },
+    });
+
+    expect(apiCalls[1]).toMatchObject({
+      url: `${BASE}/upload/signed-url`,
+      method: "POST",
+      body: {
+        assetType: "datasets",
+        assetId: "d".repeat(24),
+        filename: "birds.zip",
+        contentType: "application/zip",
+      },
+    });
+    expect(uploadCalls[0].url).toBe("https://signed.example/upload");
+    expect(
+      (uploadCalls[0].init.headers as Record<string, string>).Authorization,
+    ).toBeUndefined();
+    expect(result.summary).toBe(
+      `Extracted 3 frame(s) at ~0.5 fps from ${videoPath}; started ingest job job_123 for dataset ${"d".repeat(24)}.`,
+    );
+    expect(result.data).toMatchObject({
+      datasetId: "d".repeat(24),
+      frameCount: 3,
+      fps: 1,
+      maxFrames: 100,
+      filename: "birds.zip",
+      sessionId: "session_123",
+    });
+  });
+
+  test("falls back when probe fails", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ul-video-"));
+    const videoPath = join(dir, "birds.mp4");
+    await writeFile(videoPath, "video");
+
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: (async (url: string | URL) => {
+        const parsed = new URL(String(url));
+        if (parsed.pathname === "/api/datasets") {
+          return jsonResponse({
+            datasets: [{ _id: "d".repeat(24), slug: "data", username: "user" }],
+          });
+        }
+        if (parsed.pathname === "/api/upload/signed-url") {
+          return jsonResponse({
+            sessionId: "session_123",
+            uploadUrl: "https://signed.example/upload",
+          });
+        }
+        if (parsed.pathname === "/api/upload/complete") {
+          return jsonResponse({ ok: true });
+        }
+        return jsonResponse({
+          jobId: "job_123",
+          datasetId: "d".repeat(24),
+          status: "queued",
+        });
+      }) as unknown as typeof fetch,
+      uploadFetchImpl: (async () =>
+        new Response("", { status: 200 })) as unknown as typeof fetch,
+    });
+
+    const result = await datasetUploadVideo(client, {
+      dataset: "user/data",
+      videoPath,
+      _findTool: (name) => `/usr/bin/${name}`,
+      _probeDuration: async () => {
+        throw new Error("boom");
+      },
+      _extractFrames: async ({ outputDir, rate, maxFrames }) => {
+        expect(rate).toBe(1);
+        expect(maxFrames).toBe(100);
+        await writeFile(join(outputDir, "frame_000001.jpg"), "jpg");
+      },
+    });
+
+    expect(result.summary).toContain("probe fallback");
+  });
+
+  test("validates inputs and missing ffmpeg before network", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ul-video-"));
+    const videoPath = join(dir, "birds.mp4");
+    await writeFile(videoPath, "video");
+    const badPath = join(dir, "birds.txt");
+    await writeFile(badPath, "bad");
+
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: (async () => {
+        throw new Error("network must not be called");
+      }) as unknown as typeof fetch,
+    });
+
+    await expect(
+      datasetUploadVideo(client, { dataset: "d".repeat(24), videoPath: "" }),
+    ).rejects.toThrow(/videoPath/);
+    await expect(
+      datasetUploadVideo(client, {
+        dataset: "d".repeat(24),
+        videoPath: join(dir, "missing.mp4"),
+      }),
+    ).rejects.toThrow(/does not exist/);
+    await expect(
+      datasetUploadVideo(client, {
+        dataset: "d".repeat(24),
+        videoPath: badPath,
+      }),
+    ).rejects.toThrow(/Unsupported video file type/);
+    await expect(
+      datasetUploadVideo(client, {
+        dataset: "d".repeat(24),
+        videoPath,
+        fps: 0,
+      }),
+    ).rejects.toThrow(/fps/);
+    await expect(
+      datasetUploadVideo(client, {
+        dataset: "d".repeat(24),
+        videoPath,
+        maxFrames: 0,
+      }),
+    ).rejects.toThrow(/maxFrames/);
+    await expect(
+      datasetUploadVideo(client, {
+        dataset: "d".repeat(24),
+        videoPath,
+        _findTool: () => null,
+      }),
+    ).rejects.toThrow(/ffmpeg\/ffprobe not found on PATH/);
   });
 });
 


### PR DESCRIPTION
## Summary
Add MCP support for uploading local videos to Ultralytics Platform datasets.

## Motivation
This adds next dataset ingestion workflow while keeping video upload isolated and easy to review on its own.

## Key Changes
- add `dataset_upload_video` tool wiring with ffmpeg/ffprobe-based frame extraction and signed upload flow
- support fps, frame cap, probe fallback, and ingest handoff after generated zip upload
- add tests, parity fixture, README sync, and `fflate` dependency for frame archive generation
