### PR TITLE
feat: extend training monitor metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ resource-management tools land incrementally from here.
 | `explore_projects` / `explore_datasets` | Search public projects and datasets on Ultralytics Explore |
 | `datasets_list` / `datasets_get` / `datasets_create` / `datasets_delete` / `dataset_images_list` / `dataset_ingest` / `dataset_upload_file` / `dataset_upload_folder` / `dataset_upload_video` | Browse / create / soft-delete datasets, inspect images, start remote ingest jobs, and upload archive files, folders, or videos |
 | `models_list` / `models_get` | Browse trained models and metrics |
-| `training_monitor` | Status, progress, and latest metrics |
+| `training_monitor` | Status, progress, latest metrics, and optional recent metric history |
 | `model_predict` | Run inference on an image URL or base64 source |
 | `model_download` | Download a model weight file to a local path |
 | `gpu_availability` | Cloud GPU stock status |

--- a/fixtures/parity/training_monitor_history.json
+++ b/fixtures/parity/training_monitor_history.json
@@ -1,0 +1,100 @@
+{
+  "tool": "training_monitor",
+  "args": {
+    "model": "aaaaaaaaaaaaaaaaaaaaaaaa",
+    "include_history": true,
+    "history_last_n": 3
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/models/aaaaaaaaaaaaaaaaaaaaaaaa",
+      "response": {
+        "status": 200,
+        "json": {
+          "model": {
+            "status": "running",
+            "epochs": 100,
+            "trainResults": [
+              {
+                "epoch": 0,
+                "metrics": {
+                  "lr": 0.01
+                }
+              },
+              {
+                "epoch": 1,
+                "metrics": {
+                  "lr": 0.001
+                }
+              },
+              {
+                "epoch": 2,
+                "metrics": {
+                  "metrics/mAP50(B)": 0.52,
+                  "lr": 0.0001
+                }
+              },
+              {
+                "epoch": 3,
+                "metrics": {
+                  "metrics/mAP50(B)": 0.6,
+                  "lr": 0.00001
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/models/aaaaaaaaaaaaaaaaaaaaaaaa/training",
+      "response": {
+        "status": 404,
+        "json": {
+          "error": "Project not found"
+        }
+      }
+    }
+  ],
+  "expected": {
+    "summary": "Training status=running; epoch 4/100; ~4.0%",
+    "data": {
+      "modelId": "aaaaaaaaaaaaaaaaaaaaaaaa",
+      "status": "running",
+      "epochsDone": 4,
+      "totalEpochs": 100,
+      "progressPercentage": 4.0,
+      "etaMs": null,
+      "bestEpoch": null,
+      "bestFitness": null,
+      "latestMetrics": {
+        "metrics/mAP50(B)": 0.6
+      },
+      "progressSource": "model.trainResults",
+      "metricsHistory": [
+        {
+          "epoch": 1,
+          "metrics": {
+            "lr": 0.001
+          }
+        },
+        {
+          "epoch": 2,
+          "metrics": {
+            "metrics/mAP50(B)": 0.52,
+            "lr": 0.0001
+          }
+        },
+        {
+          "epoch": 3,
+          "metrics": {
+            "metrics/mAP50(B)": 0.6,
+            "lr": 0.00001
+          }
+        }
+      ]
+    }
+  }
+}

--- a/fixtures/parity/training_monitor_metrics.json
+++ b/fixtures/parity/training_monitor_metrics.json
@@ -1,0 +1,87 @@
+{
+  "tool": "training_monitor",
+  "args": {
+    "model": "aaaaaaaaaaaaaaaaaaaaaaaa",
+    "include_metrics": true
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/models/aaaaaaaaaaaaaaaaaaaaaaaa",
+      "response": {
+        "status": 200,
+        "json": {
+          "model": {
+            "status": "running",
+            "epochs": 100,
+            "bestEpoch": 68,
+            "bestFitness": 0.77,
+            "trainResults": [
+              {
+                "epoch": 69,
+                "metrics": {
+                  "train/box_loss": 0.72179,
+                  "metrics/mAP50(B)": 0.58282,
+                  "metrics/mAP50-95(M)": 0.48394,
+                  "lr": 0.000114
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/models/aaaaaaaaaaaaaaaaaaaaaaaa/training",
+      "response": {
+        "status": 200,
+        "json": {
+          "job": {
+            "progress": {
+              "percentage": 70
+            },
+            "timing": {
+              "elapsedMs": 1008800,
+              "timePerEpochMs": 14411.4,
+              "etaMs": 432343
+            }
+          },
+          "instanceStatus": {
+            "status": "running",
+            "uptimeSeconds": 1012
+          }
+        }
+      }
+    }
+  ],
+  "expected": {
+    "summary": "Training status=running; epoch 1/100; ~70%; ETA 7min",
+    "data": {
+      "modelId": "aaaaaaaaaaaaaaaaaaaaaaaa",
+      "status": "running",
+      "epochsDone": 1,
+      "totalEpochs": 100,
+      "progressPercentage": 70,
+      "etaMs": 432343,
+      "bestEpoch": 68,
+      "bestFitness": 0.77,
+      "latestMetrics": {
+        "train/box_loss": 0.72179,
+        "metrics/mAP50(B)": 0.58282,
+        "metrics/mAP50-95(M)": 0.48394,
+        "lr": 0.000114
+      },
+      "progressSource": "models/{id}/training",
+      "timing": {
+        "etaMs": 432343,
+        "timePerEpochMs": 14411.4,
+        "elapsedMs": 1008800
+      },
+      "instanceStatus": {
+        "status": "running",
+        "uptimeSeconds": 1012
+      }
+    }
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -432,10 +432,28 @@ export function registerActionTools(
     {
       description:
         "Report a model's training status and progress (works for private and public projects).",
-      inputSchema: { model: z.string(), project: z.string().optional() },
+      inputSchema: {
+        model: z.string(),
+        project: z.string().optional(),
+        include_metrics: z.boolean().optional(),
+        include_history: z.boolean().optional(),
+        history_last_n: z.number().int().positive().optional(),
+      },
     },
-    async ({ model, project }) =>
-      toMcpTextResult(await trainingMonitor(getClient(), model, project)),
+    async ({
+      model,
+      project,
+      include_metrics,
+      include_history,
+      history_last_n,
+    }) =>
+      toMcpTextResult(
+        await trainingMonitor(getClient(), model, project, {
+          includeMetrics: include_metrics,
+          includeHistory: include_history,
+          historyLastN: history_last_n,
+        }),
+      ),
   );
 
   server.registerTool(

--- a/src/tools/training.ts
+++ b/src/tools/training.ts
@@ -18,12 +18,32 @@ function formatPercent(value: number): string {
   return Number.isInteger(value) ? value.toFixed(1) : String(value);
 }
 
+function validateHistoryLastN(historyLastN: number): void {
+  if (!Number.isInteger(historyLastN) || historyLastN <= 0) {
+    throw new Error("`history_last_n` must be a positive integer.");
+  }
+}
+
+interface TrainingMonitorOptions {
+  includeMetrics?: boolean;
+  includeHistory?: boolean;
+  historyLastN?: number;
+}
+
 /** Report model training status using private-safe model trainResults. */
 export async function trainingMonitor(
   client: UltralyticsClient,
   model: string,
   project?: string,
+  options: TrainingMonitorOptions = {},
 ): Promise<NormalizedToolResult> {
+  const {
+    includeMetrics = false,
+    includeHistory = false,
+    historyLastN = 20,
+  } = options;
+  validateHistoryLastN(historyLastN);
+
   const modelId = await resolveModel(client, model, project);
   const data = await client.get(`/models/${modelId}`);
   const record = asRecord(data);
@@ -46,21 +66,40 @@ export async function trainingMonitor(
       keyMetrics[key] = latestMetrics[key];
     }
   }
+  const metricsHistory = trainResults.slice(-historyLastN).map((entry) => {
+    const record = asRecord(entry);
+    return {
+      epoch: record.epoch ?? null,
+      metrics: asRecord(record.metrics),
+    };
+  });
 
   let progressPct: number | null = null;
   let progressText: string | null = null;
   let etaMs: number | null = null;
   let source = "model.trainResults";
+  let timing: Record<string, unknown> | null = null;
+  let instanceStatus: Record<string, unknown> | null = null;
 
   try {
     const trainingData = await client.get(`/models/${modelId}/training`);
-    const job = asRecord(asRecord(trainingData).job);
+    const trainingRecord = asRecord(trainingData);
+    const job = asRecord(trainingRecord.job);
     const progress = asRecord(job.progress);
-    const timing = asRecord(job.timing);
+    const timingRecord = asRecord(job.timing);
     progressPct = (progress.percentage as number | undefined) ?? null;
     progressText = progressPct === null ? null : String(progressPct);
-    etaMs = (timing.etaMs as number | undefined) ?? null;
+    etaMs = (timingRecord.etaMs as number | undefined) ?? null;
     source = "models/{id}/training";
+    timing = {
+      etaMs: timingRecord.etaMs ?? null,
+      timePerEpochMs: timingRecord.timePerEpochMs ?? null,
+      elapsedMs: timingRecord.elapsedMs ?? null,
+    };
+    instanceStatus =
+      "instanceStatus" in trainingRecord
+        ? asRecord(trainingRecord.instanceStatus)
+        : null;
   } catch (error) {
     if (
       !(error instanceof UltralyticsApiError) ||
@@ -92,8 +131,15 @@ export async function trainingMonitor(
       etaMs,
       bestEpoch: item.bestEpoch ?? null,
       bestFitness: item.bestFitness ?? null,
-      latestMetrics: keyMetrics,
+      latestMetrics: includeMetrics ? latestMetrics : keyMetrics,
       progressSource: source,
+      ...(includeMetrics
+        ? {
+            timing,
+            instanceStatus,
+          }
+        : {}),
+      ...(includeHistory ? { metricsHistory } : {}),
     },
   };
 }

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -264,6 +264,11 @@ const TOOL_RUNNERS: Record<
       client,
       args.model as string,
       args.project as string | undefined,
+      {
+        includeMetrics: args.include_metrics as boolean | undefined,
+        includeHistory: args.include_history as boolean | undefined,
+        historyLastN: args.history_last_n as number | undefined,
+      },
     ),
 };
 
@@ -311,6 +316,8 @@ describe("parity fixtures", () => {
         "projects_create.json",
         "projects_delete.json",
         "projects_list.json",
+        "training_monitor_history.json",
+        "training_monitor_metrics.json",
         "training_monitor_private.json",
       ].sort(),
     );

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -109,4 +109,14 @@ test("server registers all available tools over the protocol", async () => {
     "dataset",
     "video_path",
   ]);
+
+  const trainingMonitor = tools.find(
+    (tool) => tool.name === "training_monitor",
+  );
+  expect(trainingMonitor?.inputSchema?.required).toEqual(["model"]);
+  expect(trainingMonitor?.inputSchema?.properties).toMatchObject({
+    include_metrics: expect.any(Object),
+    include_history: expect.any(Object),
+    history_last_n: expect.any(Object),
+  });
 });

--- a/tests/tools/training.test.ts
+++ b/tests/tools/training.test.ts
@@ -67,6 +67,147 @@ describe("trainingMonitor", () => {
     });
   });
 
+  test("include_metrics returns full latest metrics with live extras", async () => {
+    const { client } = routeClient((path) => {
+      if (path === `/api/models/${ID}`) {
+        return jsonResponse({
+          model: {
+            status: "running",
+            epochs: 100,
+            trainResults: [
+              {
+                epoch: 69,
+                metrics: {
+                  "train/box_loss": 0.72179,
+                  "metrics/mAP50(B)": 0.58282,
+                  "metrics/mAP50-95(M)": 0.48394,
+                  lr: 0.000114,
+                },
+              },
+            ],
+          },
+        });
+      }
+      if (path === `/api/models/${ID}/training`) {
+        return jsonResponse({
+          job: {
+            progress: { percentage: 70 },
+            timing: {
+              etaMs: 432343,
+              timePerEpochMs: 14411.4,
+              elapsedMs: 1008800,
+            },
+          },
+          instanceStatus: { status: "running", uptimeSeconds: 1012 },
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const result = await trainingMonitor(client, ID, undefined, {
+      includeMetrics: true,
+    });
+    expect(result.data).toMatchObject({
+      latestMetrics: {
+        "train/box_loss": 0.72179,
+        "metrics/mAP50(B)": 0.58282,
+        "metrics/mAP50-95(M)": 0.48394,
+        lr: 0.000114,
+      },
+      timing: {
+        etaMs: 432343,
+        timePerEpochMs: 14411.4,
+        elapsedMs: 1008800,
+      },
+      instanceStatus: { status: "running", uptimeSeconds: 1012 },
+    });
+  });
+
+  test.each([
+    401, 403, 404,
+  ])("include_metrics falls back on /training %s", async (statusCode) => {
+    const { client } = routeClient((path) => {
+      if (path === `/api/models/${ID}`) {
+        return jsonResponse({
+          model: {
+            status: "running",
+            epochs: 100,
+            trainResults: [
+              {
+                epoch: 0,
+                metrics: {
+                  "train/box_loss": 1.23,
+                  "metrics/mAP50(B)": 0.5,
+                },
+              },
+            ],
+          },
+        });
+      }
+      if (path === `/api/models/${ID}/training`) {
+        return jsonResponse({ error: "not available" }, statusCode);
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const result = await trainingMonitor(client, ID, undefined, {
+      includeMetrics: true,
+    });
+    expect(result.data).toMatchObject({
+      progressSource: "model.trainResults",
+      latestMetrics: {
+        "train/box_loss": 1.23,
+        "metrics/mAP50(B)": 0.5,
+      },
+      timing: null,
+      instanceStatus: null,
+    });
+  });
+
+  test("include_history returns recent verbatim series", async () => {
+    const { client } = routeClient((path) => {
+      if (path === `/api/models/${ID}`) {
+        return jsonResponse({
+          model: {
+            status: "running",
+            epochs: 100,
+            trainResults: [
+              { epoch: 0, metrics: { lr: 0.01 } },
+              { epoch: 1, metrics: { lr: 0.001 } },
+              { epoch: 2, metrics: { lr: 0.0001 } },
+              { epoch: 3, metrics: { "metrics/mAP50(B)": 0.6, lr: 0.00001 } },
+            ],
+          },
+        });
+      }
+      if (path === `/api/models/${ID}/training`) {
+        return jsonResponse({ error: "Project not found" }, 404);
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const result = await trainingMonitor(client, ID, undefined, {
+      includeHistory: true,
+      historyLastN: 2,
+    });
+    expect(result.data).toMatchObject({
+      latestMetrics: { "metrics/mAP50(B)": 0.6 },
+      metricsHistory: [
+        { epoch: 2, metrics: { lr: 0.0001 } },
+        { epoch: 3, metrics: { "metrics/mAP50(B)": 0.6, lr: 0.00001 } },
+      ],
+    });
+  });
+
+  test.each([
+    0, -1, 2.5,
+  ])("rejects invalid historyLastN=%s", async (historyLastN) => {
+    const { client } = routeClient(() => jsonResponse({}, 500));
+    await expect(
+      trainingMonitor(client, ID, undefined, { historyLastN }),
+    ).rejects.toThrow(/history_last_n/);
+  });
+
   test("unknown epoch total skips percentage math", async () => {
     const { client } = routeClient((path) => {
       if (path === `/api/models/${ID}`) {
@@ -110,6 +251,32 @@ describe("trainingMonitor", () => {
     );
     expect(error).toBeInstanceOf(UltralyticsApiError);
     expect(error.statusCode).toBe(500);
+  });
+
+  test("re-raises rate limit errors from /training", async () => {
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      maxRetries: 0,
+      fetchImpl: (async (url: string | URL) => {
+        const path = new URL(String(url)).pathname;
+        if (path === `/api/models/${ID}`) {
+          return jsonResponse({
+            model: { status: "running", epochs: 100, trainResults: [] },
+          });
+        }
+        if (path === `/api/models/${ID}/training`) {
+          return jsonResponse({ error: "slow down" }, 429);
+        }
+        return jsonResponse({}, 404);
+      }) as unknown as typeof fetch,
+    });
+
+    const error = await trainingMonitor(client, ID).catch(
+      (e) => e as UltralyticsApiError,
+    );
+    expect(error).toBeInstanceOf(UltralyticsApiError);
+    expect(error.statusCode).toBe(429);
   });
 });
 


### PR DESCRIPTION
## Summary
Extend `training_monitor` with optional full metrics and recent history output.

## Motivation
This keeps default monitoring output compact while allowing richer training diagnostics when explicitly requested.

## Key Changes
- add `include_metrics`, `include_history`, and `history_last_n` support to `training_monitor`
- return live timing and instance status with full metrics output, and recent metric snapshots with history output
- add tests, parity fixtures, and README sync for the expanded monitor behavior
