### PR TITLE
ci: add actions write permission

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
## Summary
Add explicit Actions write permission to the release preparation workflow.

## Motivation
Prepare Release can already create bump PRs and tags, but dispatching the Release workflow still fails without Actions-level write permission.

## Key Changes
- add `actions: write` to `prepare-release.yml`
- keep existing contents and pull request write permissions unchanged
- allow automated tag creation to dispatch the Release workflow without a 403
