### PR TITLE
fix: sync server version with package metadata

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,21 @@
+import { readFileSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { UltralyticsClient } from "./client.js";
 import { registerTools } from "./tools/index.js";
+
+type PackageJson = {
+  version: string;
+};
+
+function readPackageVersion(): string {
+  const packageJson = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  ) as PackageJson;
+  return packageJson.version;
+}
+
+export const SERVER_VERSION = readPackageVersion();
 
 /** Create the MCP server with all tools registered.
  *
@@ -12,7 +26,10 @@ import { registerTools } from "./tools/index.js";
 export function createServer(
   clientFactory: () => UltralyticsClient = () => new UltralyticsClient(),
 ): McpServer {
-  const server = new McpServer({ name: "ultralytics", version: "0.2.0" });
+  const server = new McpServer({
+    name: "ultralytics",
+    version: SERVER_VERSION,
+  });
 
   let client: UltralyticsClient | undefined;
   const getClient = (): UltralyticsClient => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,8 +1,9 @@
+import { readFileSync } from "node:fs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { afterEach, expect, test } from "vitest";
 
-import { createServer } from "../src/server.js";
+import { createServer, SERVER_VERSION } from "../src/server.js";
 import { TOOL_NAMES } from "../src/tools/index.js";
 
 const cleanups: Array<() => Promise<void>> = [];
@@ -14,6 +15,16 @@ afterEach(async () => {
       await cleanup();
     }
   }
+});
+
+test("server version stays in sync with package.json", () => {
+  const packageJson = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  ) as {
+    version: string;
+  };
+
+  expect(SERVER_VERSION).toBe(packageJson.version);
 });
 
 test("server registers all available tools over the protocol", async () => {


### PR DESCRIPTION
## Summary
Sync MCP server version with package metadata and add coverage to prevent drift.

## Motivation
Avoid mismatches between the version reported by the server and the package version used for releases.

## Key Changes
- read server version from `package.json` instead of hardcoding it in `src/server.ts`
- export `SERVER_VERSION` for reuse and verification
- add test coverage to ensure server version stays in sync with package metadata
