### PR TITLE
ci: fix release version bump lockfile sync

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -79,11 +79,7 @@ jobs:
           git fetch origin main
           git checkout -B "$BRANCH" origin/main
 
-          jq --arg v "${{ steps.version.outputs.next_version }}" '.version=$v' package.json > package.json.tmp
-          mv package.json.tmp package.json
-
-          jq --arg v "${{ steps.version.outputs.next_version }}" '.version=$v' package-lock.json > package-lock.json.tmp
-          mv package-lock.json.tmp package-lock.json
+          node scripts/bump-version.mjs "${{ steps.version.outputs.next_version }}"
 
           git add package.json package-lock.json
           git commit -m "chore: bump version to ${{ steps.version.outputs.next_tag }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "ultralytics-mcp",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const [, , version, targetDir = "."] = process.argv;
+
+if (!version) {
+  console.error("Usage: node scripts/bump-version.mjs <version> [dir]");
+  process.exit(1);
+}
+
+execFileSync(
+  "npm",
+  ["version", version, "--no-git-tag-version", "--allow-same-version"],
+  {
+    cwd: resolve(targetDir),
+    stdio: "inherit",
+  },
+);

--- a/tests/version-bump-script.test.ts
+++ b/tests/version-bump-script.test.ts
@@ -1,0 +1,69 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, expect, test } from "vitest";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("version bump script repairs nested lockfile version on same-version rerun", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ultralytics-version-bump-"));
+  tempDirs.push(dir);
+
+  const packageJsonPath = join(dir, "package.json");
+  const packageLockPath = join(dir, "package-lock.json");
+
+  writeFileSync(
+    packageJsonPath,
+    JSON.stringify(
+      {
+        name: "fixture-package",
+        version: "0.1.4",
+      },
+      null,
+      2,
+    ),
+  );
+
+  execFileSync("npm", ["install", "--package-lock-only"], {
+    cwd: dir,
+    stdio: "pipe",
+  });
+
+  const lockfile = JSON.parse(readFileSync(packageLockPath, "utf8")) as {
+    version: string;
+    packages: { "": { version: string } };
+  };
+  lockfile.version = "0.1.4";
+  lockfile.packages[""].version = "0.1.3";
+  writeFileSync(packageLockPath, JSON.stringify(lockfile, null, 2));
+
+  execFileSync(
+    "node",
+    [join(process.cwd(), "scripts", "bump-version.mjs"), "0.1.4", dir],
+    {
+      stdio: "pipe",
+    },
+  );
+
+  const updatedPackageJson = JSON.parse(
+    readFileSync(packageJsonPath, "utf8"),
+  ) as {
+    version: string;
+  };
+  const updatedLockfile = JSON.parse(readFileSync(packageLockPath, "utf8")) as {
+    version: string;
+    packages: { "": { version: string } };
+  };
+
+  expect(updatedPackageJson.version).toBe("0.1.4");
+  expect(updatedLockfile.version).toBe("0.1.4");
+  expect(updatedLockfile.packages[""].version).toBe("0.1.4");
+});


### PR DESCRIPTION
## Summary
Fix release bump automation so package metadata and lockfile versions stay in sync.

## Motivation
The prepare-release workflow only updated the top-level `package-lock.json` version field, which let the nested root package version drift from `package.json`.

## Key Changes
- replace manual `jq` version edits with `npm version --no-git-tag-version --allow-same-version`
- add a small helper script used by the release workflow for version bumps
- add test coverage for same-version reruns repairing nested lockfile version drift
- repair the current `package-lock.json` nested root package version mismatch
