### PR TITLE
feat: add base checkpoint training support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ You should see `ultralytics` in configured MCP servers.
 - Download model weights to local path
 - Create exports and training jobs with explicit cost confirmation
 - Pass advanced YOLO training settings through `training_start.train_args`
+- Start training from existing project models or official YOLO base checkpoints
 
 ## Tools (27)
 
@@ -186,7 +187,7 @@ You should see `ultralytics` in configured MCP servers.
 | Tool | Description |
 | --- | --- |
 | `training_monitor` | Inspect status, progress, latest metrics, and optional history |
-| `training_start` | Start a cloud training job with explicit cost confirmation and optional `train_args` passthrough |
+| `training_start` | Start a cloud training job from an existing model or official YOLO base checkpoint, with explicit cost confirmation and optional `train_args` passthrough |
 
 ### Exports (3 tools)
 

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -24,6 +24,13 @@ interface Resource {
   username?: string;
 }
 
+export interface ResolvedDatasetDetails {
+  id: string;
+  task: string | null;
+  name: string | null;
+  slug: string | null;
+}
+
 /** Return true when `ref` is a 24-hex Platform object id. */
 export function looksLikeId(ref: string): boolean {
   return ID_RE.test(ref.trim());
@@ -62,6 +69,16 @@ function listField(data: unknown, field: string): Resource[] {
     }
   }
   return [];
+}
+
+function recordField(data: unknown, field: string): Record<string, unknown> {
+  if (data && typeof data === "object") {
+    const value = (data as Record<string, unknown>)[field];
+    if (value && typeof value === "object") {
+      return value as Record<string, unknown>;
+    }
+  }
+  return {};
 }
 
 function select(matches: Resource[], kind: string, ref: string): Resource {
@@ -164,6 +181,27 @@ export async function resolveDataset(
       (username === null || dataset.username === username),
   );
   return select(matches, "dataset", ref)._id as string;
+}
+
+/** Resolve a dataset ref and return its id plus task metadata. */
+export async function resolveDatasetDetails(
+  client: UltralyticsClient,
+  ref: string,
+): Promise<ResolvedDatasetDetails> {
+  const id = await resolveDataset(client, ref);
+  const data = await client.get(`/datasets/${id}`);
+  const dataset =
+    data &&
+    typeof data === "object" &&
+    "dataset" in (data as Record<string, unknown>)
+      ? recordField(data, "dataset")
+      : ((data as Record<string, unknown> | null) ?? {});
+  return {
+    id,
+    task: typeof dataset.task === "string" ? dataset.task : null,
+    name: typeof dataset.name === "string" ? dataset.name : null,
+    slug: typeof dataset.slug === "string" ? dataset.slug : null,
+  };
 }
 
 /** Resolve a model id, slug plus project, or model ul:// URI. */

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -582,7 +582,7 @@ export function registerWriteTools(
     "training_start",
     {
       description:
-        "Start a cloud training job (state-changing, may cost credits). Requires confirm_cost=true.",
+        "Start a cloud training job from an existing model or official YOLO base checkpoint (state-changing, may cost credits). Requires confirm_cost=true.",
       inputSchema: {
         model: z.string(),
         project: z.string(),

--- a/src/tools/training.ts
+++ b/src/tools/training.ts
@@ -2,7 +2,12 @@
 
 import type { UltralyticsClient } from "../client.js";
 import { UltralyticsApiError } from "../errors.js";
-import { resolveDataset, resolveModel, resolveProject } from "../resolve.js";
+import {
+  resolveDataset,
+  resolveDatasetDetails,
+  resolveModel,
+  resolveProject,
+} from "../resolve.js";
 import type { NormalizedToolResult } from "../tool-result.js";
 import { asRecord, pyField } from "./shared.js";
 
@@ -13,6 +18,23 @@ const KEY_METRICS = [
   "metrics/mAP50-95(M)",
 ];
 const RESERVED_TRAIN_ARG_KEYS = ["data", "model"] as const;
+const CHECKPOINT_TASK_SUFFIXES = [
+  ["-seg", "segment"],
+  ["-sem", "semantic"],
+  ["-pose", "pose"],
+  ["-obb", "obb"],
+  ["-cls", "classify"],
+] as const;
+const BASE_CHECKPOINT_RE =
+  /^yolo(?:26|11|v8|v5)[nslmx](?:-(?:seg|sem|pose|obb|cls))?(?:\.pt)?$/i;
+const DATASET_TASK_COMPATIBILITY: Record<string, string[]> = {
+  detect: ["detect"],
+  segment: ["segment", "semantic"],
+  semantic: ["semantic"],
+  pose: ["pose"],
+  obb: ["obb"],
+  classify: ["classify"],
+};
 
 /** Format a percentage like Python's `str(round(x, 1))` (whole numbers keep `.0`). */
 function formatPercent(value: number): string {
@@ -33,6 +55,59 @@ function validateTrainArgs(trainArgs: Record<string, unknown>): void {
       );
     }
   }
+}
+
+function normalizeCheckpointRef(ref: string): string {
+  const trimmed = ref.trim();
+  return trimmed.toLowerCase().endsWith(".pt") ? trimmed : `${trimmed}.pt`;
+}
+
+function inferCheckpointTask(ref: string): string | null {
+  const trimmed = ref.trim();
+  if (!BASE_CHECKPOINT_RE.test(trimmed)) {
+    return null;
+  }
+  const normalized = normalizeCheckpointRef(trimmed).toLowerCase();
+  for (const [suffix, task] of CHECKPOINT_TASK_SUFFIXES) {
+    if (normalized.endsWith(`${suffix}.pt`)) {
+      return task;
+    }
+  }
+  return "detect";
+}
+
+function checkpointModelName(ref: string): string {
+  return normalizeCheckpointRef(ref).replace(/\.pt$/i, "");
+}
+
+function validateCheckpointCompatibility(
+  datasetTask: string | null,
+  checkpointTask: string,
+): void {
+  if (datasetTask === null) {
+    throw new Error(
+      "Resolved dataset is missing a task; cannot select a base checkpoint.",
+    );
+  }
+  const allowedTasks = DATASET_TASK_COMPATIBILITY[datasetTask];
+  if (!allowedTasks) {
+    throw new Error(`Unsupported dataset task '${datasetTask}'.`);
+  }
+  if (!allowedTasks.includes(checkpointTask)) {
+    throw new Error(
+      `Checkpoint task '${checkpointTask}' is not compatible with dataset task '${datasetTask}'.`,
+    );
+  }
+}
+
+function createdModelId(data: unknown): string {
+  const record = asRecord(data);
+  const item = asRecord("model" in record ? record.model : data);
+  const id = item._id;
+  if (typeof id !== "string" || !id.trim()) {
+    throw new Error("Create model response did not include a model id.");
+  }
+  return id;
 }
 
 interface TrainingMonitorOptions {
@@ -191,14 +266,33 @@ export async function trainingStart(
   }
   validateTrainArgs(passthroughTrainArgs);
 
-  const modelId = await resolveModel(client, model, project);
   const projectId = await resolveProject(client, project);
-  const datasetId = await resolveDataset(client, dataset);
+  const checkpointTask = inferCheckpointTask(model);
+  const datasetDetails =
+    checkpointTask === null
+      ? { id: await resolveDataset(client, dataset), task: null }
+      : await resolveDatasetDetails(client, dataset);
+  const datasetId = datasetDetails.id;
 
+  let modelId: string;
   const trainArgs: Record<string, unknown> = {
     ...passthroughTrainArgs,
     data: datasetId,
   };
+  if (checkpointTask === null) {
+    modelId = await resolveModel(client, model, project);
+  } else {
+    validateCheckpointCompatibility(datasetDetails.task, checkpointTask);
+    const checkpoint = normalizeCheckpointRef(model);
+    const created = await client.postJson("/models", {
+      projectId,
+      task: checkpointTask,
+      name: checkpointModelName(checkpoint),
+    });
+    modelId = createdModelId(created);
+    trainArgs.model = checkpoint;
+  }
+
   if (epochs !== undefined) {
     if (epochs <= 0) {
       throw new Error("`epochs` must be greater than 0.");

--- a/tests/tools/training.test.ts
+++ b/tests/tools/training.test.ts
@@ -431,4 +431,148 @@ describe("trainingStart", () => {
       }),
     ).rejects.toThrow(/train_args/);
   });
+
+  test("creates a model record before starting training from a detect checkpoint", async () => {
+    const createdModelId = "m".repeat(24);
+    const calls: { url: string; method: string; body: unknown }[] = [];
+    const impl = (async (url: string | URL, init: RequestInit = {}) => {
+      let body: unknown;
+      if (typeof init.body === "string") {
+        body = JSON.parse(init.body);
+      }
+      calls.push({
+        url: String(url),
+        method: (init.method ?? "GET").toUpperCase(),
+        body,
+      });
+      const path = new URL(String(url)).pathname;
+      if (path === `/api/datasets/${DATASET}`) {
+        return jsonResponse({ dataset: { _id: DATASET, task: "detect" } });
+      }
+      if (path === "/api/models") {
+        return jsonResponse({ model: { _id: createdModelId, task: "detect" } });
+      }
+      if (path === "/api/training/start") {
+        return jsonResponse({ job: { _id: "j".repeat(24), status: "queued" } });
+      }
+      return jsonResponse({}, 404);
+    }) as unknown as typeof fetch;
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: impl,
+    });
+
+    await trainingStart(client, {
+      model: "yolo26n.pt",
+      project: PROJECT,
+      dataset: DATASET,
+      gpuType: "rtx-4090",
+      epochs: 100,
+      confirmCost: true,
+    });
+
+    expect(calls).toMatchObject([
+      {
+        url: `${BASE}/datasets/${DATASET}`,
+        method: "GET",
+      },
+      {
+        url: `${BASE}/models`,
+        method: "POST",
+        body: {
+          projectId: PROJECT,
+          task: "detect",
+          name: "yolo26n",
+        },
+      },
+      {
+        url: `${BASE}/training/start`,
+        method: "POST",
+        body: {
+          modelId: createdModelId,
+          projectId: PROJECT,
+          gpuType: "rtx-4090",
+          trainArgs: {
+            model: "yolo26n.pt",
+            data: DATASET,
+            epochs: 100,
+          },
+        },
+      },
+    ]);
+  });
+
+  test("allows semantic checkpoints for segment datasets and creates a semantic model", async () => {
+    const calls: { url: string; method: string; body: unknown }[] = [];
+    const impl = (async (url: string | URL, init: RequestInit = {}) => {
+      let body: unknown;
+      if (typeof init.body === "string") {
+        body = JSON.parse(init.body);
+      }
+      calls.push({
+        url: String(url),
+        method: (init.method ?? "GET").toUpperCase(),
+        body,
+      });
+      const path = new URL(String(url)).pathname;
+      if (path === `/api/datasets/${DATASET}`) {
+        return jsonResponse({ dataset: { _id: DATASET, task: "segment" } });
+      }
+      if (path === "/api/models") {
+        return jsonResponse({
+          model: { _id: "m".repeat(24), task: "semantic" },
+        });
+      }
+      if (path === "/api/training/start") {
+        return jsonResponse({ job: { _id: "j".repeat(24), status: "queued" } });
+      }
+      return jsonResponse({}, 404);
+    }) as unknown as typeof fetch;
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: impl,
+    });
+
+    await trainingStart(client, {
+      model: "yolo26n-sem.pt",
+      project: PROJECT,
+      dataset: DATASET,
+      gpuType: "rtx-4090",
+      confirmCost: true,
+    });
+
+    expect(calls[1]).toMatchObject({
+      url: `${BASE}/models`,
+      method: "POST",
+      body: {
+        projectId: PROJECT,
+        task: "semantic",
+        name: "yolo26n-sem",
+      },
+    });
+  });
+
+  test("rejects incompatible checkpoint and dataset task combinations", async () => {
+    const { client, calls } = routeClient((path) => {
+      if (path === `/api/datasets/${DATASET}`) {
+        return jsonResponse({ dataset: { _id: DATASET, task: "semantic" } });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    await expect(
+      trainingStart(client, {
+        model: "yolo26n-seg.pt",
+        project: PROJECT,
+        dataset: DATASET,
+        gpuType: "rtx-4090",
+        confirmCost: true,
+      }),
+    ).rejects.toThrow(/not compatible/);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.path).toBe(`/api/datasets/${DATASET}`);
+  });
 });


### PR DESCRIPTION
## Summary
Add base checkpoint support to `training_start`.

## Motivation
Training fresh from official YOLO checkpoints currently requires leaving the MCP flow and calling the API directly.

## Key Changes
- detect official YOLO base checkpoint inputs in `training_start`
- resolve dataset details so training can validate dataset and checkpoint task compatibility
- create a destination model record before starting cloud training from a checkpoint
- add test coverage for checkpoint training and task compatibility
- document base checkpoint support in the README