### PR TITLE
docs: expand install docs and track latest package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Ultralytics Platform MCP
 
 [![npm version](https://img.shields.io/npm/v/ultralytics-mcp.svg)](https://www.npmjs.com/package/ultralytics-mcp)
-[![npm downloads](https://img.shields.io/npm/dm/ultralytics-mcp.svg)](https://www.npmjs.com/package/ultralytics-mcp)
 [![CI](https://github.com/amanharshx/ultralytics-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/amanharshx/ultralytics-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
@@ -20,8 +19,6 @@ dataset uploads.
 - [Get API Key](#get-api-key)
 - [Environment Variables](#environment-variables)
 - [Installation](#installation)
-  - [Claude Code](#claude-code)
-  - [Codex](#codex)
 - [Verify Setup](#verify-setup)
 - [What You Can Do](#what-you-can-do)
 - [Tools](#tools)
@@ -62,7 +59,7 @@ Works in many MCP clients that accept JSON stdio server definitions.
   "mcpServers": {
     "ultralytics": {
       "command": "npx",
-      "args": ["-y", "ultralytics-mcp"],
+      "args": ["-y", "ultralytics-mcp@latest"],
       "env": {
         "ULTRALYTICS_API_KEY": "ul_your_api_key_here"
       }
@@ -71,12 +68,34 @@ Works in many MCP clients that accept JSON stdio server definitions.
 }
 ```
 
-### Claude Code
+<details>
+<summary>Antigravity</summary>
+
+Add via the Antigravity settings or by updating your configuration file:
+
+```json
+{
+  "mcpServers": {
+    "ultralytics": {
+      "command": "npx",
+      "args": ["-y", "ultralytics-mcp@latest"],
+      "env": {
+        "ULTRALYTICS_API_KEY": "ul_your_api_key_here"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>Claude Code</summary>
 
 Add server with Claude Code CLI:
 
 ```bash
-claude mcp add ultralytics --env ULTRALYTICS_API_KEY=ul_your_api_key_here -- npx -y ultralytics-mcp
+claude mcp add ultralytics --env ULTRALYTICS_API_KEY=ul_your_api_key_here -- npx -y ultralytics-mcp@latest
 ```
 
 Or add a project-scoped server in repo-root `.mcp.json`:
@@ -86,7 +105,7 @@ Or add a project-scoped server in repo-root `.mcp.json`:
   "mcpServers": {
     "ultralytics": {
       "command": "npx",
-      "args": ["-y", "ultralytics-mcp"],
+      "args": ["-y", "ultralytics-mcp@latest"],
       "env": {
         "ULTRALYTICS_API_KEY": "ul_your_api_key_here"
       }
@@ -95,12 +114,22 @@ Or add a project-scoped server in repo-root `.mcp.json`:
 }
 ```
 
-### Codex
+</details>
+
+<details>
+<summary>Claude Desktop</summary>
+
+Follow the MCP install [guide](https://modelcontextprotocol.io/quickstart/user), use the standard config above.
+
+</details>
+
+<details>
+<summary>Codex</summary>
 
 Add server with Codex CLI:
 
 ```bash
-codex mcp add ultralytics --env ULTRALYTICS_API_KEY=ul_your_api_key_here -- npx -y ultralytics-mcp
+codex mcp add ultralytics --env ULTRALYTICS_API_KEY=ul_your_api_key_here -- npx -y ultralytics-mcp@latest
 ```
 
 Or add it directly to `~/.codex/config.toml`:
@@ -108,11 +137,61 @@ Or add it directly to `~/.codex/config.toml`:
 ```toml
 [mcp_servers.ultralytics]
 command = "npx"
-args = ["-y", "ultralytics-mcp"]
+args = ["-y", "ultralytics-mcp@latest"]
 
 [mcp_servers.ultralytics.env]
 ULTRALYTICS_API_KEY = "ul_your_api_key_here"
 ```
+
+</details>
+
+<details>
+<summary>Cursor</summary>
+
+#### Click the button to install:
+
+[<img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Install in Cursor">](https://cursor.com/en/install-mcp?name=ultralytics&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsInVsdHJhbHl0aWNzLW1jcEBsYXRlc3QiXSwiZW52Ijp7IlVMVFJBTFlUSUNTX0FQSV9LRVkiOiJ1bF95b3VyX2FwaV9rZXlfaGVyZSJ9fQ%3D%3D)
+
+> [!IMPORTANT]
+> The install button writes a placeholder key. After installing, open your Cursor MCP config and replace `ul_your_api_key_here` with your Ultralytics API key, then restart Cursor.
+
+#### Or install manually:
+
+Go to `Cursor Settings` -> `MCP` -> `Add new MCP Server` (or edit `~/.cursor/mcp.json` directly) and use the standard config above: `command` set to `npx`, `args` set to `["-y", "ultralytics-mcp@latest"]`, and `ULTRALYTICS_API_KEY` in `env`.
+
+</details>
+
+<details>
+<summary>Gemini CLI</summary>
+
+Follow the MCP install [guide](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md#configure-the-mcp-server-in-settingsjson), use the standard config above.
+
+</details>
+
+<details>
+<summary>VS Code / Copilot</summary>
+
+#### Click the button to install:
+
+[<img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Server&color=0098FF" alt="Install in VS Code">](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522ultralytics%2522%252C%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522-y%2522%252C%2522ultralytics-mcp%2540latest%2522%255D%252C%2522env%2522%253A%257B%2522ULTRALYTICS_API_KEY%2522%253A%2522ul_your_api_key_here%2522%257D%257D)
+
+> [!IMPORTANT]
+> The install button writes a placeholder key. After installing, open your VS Code MCP config and replace `ul_your_api_key_here` with your Ultralytics API key, then restart VS Code.
+
+#### Or install manually:
+
+Follow the MCP install [guide](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server), use the standard config above. You can also install the server using the VS Code CLI:
+
+```bash
+# For VS Code
+code --add-mcp '{"name":"ultralytics","command":"npx","args":["-y","ultralytics-mcp@latest"],"env":{"ULTRALYTICS_API_KEY":"ul_your_api_key_here"}}'
+```
+
+After installation, the Ultralytics MCP server will be available for use with your GitHub Copilot agent in VS Code.
+
+</details>
+
+These examples track latest published npm release. Restart MCP client or session after upgrading so new server process picks up latest package.
 
 ## Verify Setup
 
@@ -186,7 +265,7 @@ characters after prefix.
 ### Manual server smoke test
 
 ```bash
-ULTRALYTICS_API_KEY=ul_your_api_key_here npx -y ultralytics-mcp
+ULTRALYTICS_API_KEY=ul_your_api_key_here npx -y ultralytics-mcp@latest
 ```
 
 If command exits immediately with config error, fix environment first.


### PR DESCRIPTION
## Summary
Expand README installation guidance across supported MCP clients and switch install examples to `ultralytics-mcp@latest`.

## Motivation
Make MCP setup easier across common clients and align default install docs with the latest published package flow.

## Key Changes
- replace install examples with `ultralytics-mcp@latest`
- add client-specific setup sections for more MCP hosts
- add restart guidance after upgrades
- remove npm downloads badge