### PR TITLE
fix: register only read-only tools in registerReadTools

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,9 +1,9 @@
 /** Tool registration for the MCP server.
  *
  * Logic functions live in the sibling modules and are re-exported for tests and
- * the parity fixture runner. `registerReadTools` wires them onto an `McpServer`
- * with Zod input schemas. User-facing tool names stay snake_case for parity with
- * the Python package.
+ * the parity fixture runner. Registration helpers wire tools onto an
+ * `McpServer` with Zod input schemas. User-facing tool names stay snake_case for
+ * parity with the Python package.
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -157,7 +157,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   }),
   tool({
     name: "projects_create",
-    registrationGroup: "read",
+    registrationGroup: "write",
     stateChanging: true,
     description: "Create a project in your Ultralytics workspace.",
     inputSchema: {
@@ -183,7 +183,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   }),
   tool({
     name: "projects_delete",
-    registrationGroup: "read",
+    registrationGroup: "write",
     stateChanging: true,
     description:
       "Soft-delete a project by id, slug, username/slug, or project ul:// URI.",
@@ -263,7 +263,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   }),
   tool({
     name: "datasets_create",
-    registrationGroup: "read",
+    registrationGroup: "write",
     stateChanging: true,
     description: "Create a dataset in your Ultralytics workspace.",
     inputSchema: {
@@ -364,7 +364,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   }),
   tool({
     name: "dataset_version_create",
-    registrationGroup: "read",
+    registrationGroup: "write",
     stateChanging: true,
     description: "Create a frozen dataset version snapshot.",
     inputSchema: {
@@ -390,7 +390,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   }),
   tool({
     name: "datasets_delete",
-    registrationGroup: "read",
+    registrationGroup: "write",
     stateChanging: true,
     description:
       "Soft-delete a dataset by id, slug, username/slug, or dataset ul:// URI.",
@@ -411,7 +411,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   }),
   tool({
     name: "dataset_ingest",
-    registrationGroup: "read",
+    registrationGroup: "write",
     stateChanging: true,
     description: "Start a remote URL ingest job for an existing dataset.",
     inputSchema: {
@@ -440,7 +440,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   }),
   tool({
     name: "dataset_upload_file",
-    registrationGroup: "read",
+    registrationGroup: "write",
     stateChanging: true,
     description:
       "Upload a local dataset archive file and start ingest for an existing dataset.",
@@ -481,7 +481,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   }),
   tool({
     name: "dataset_upload_folder",
-    registrationGroup: "read",
+    registrationGroup: "write",
     stateChanging: true,
     description:
       "Upload a local image folder as a zip and start ingest for an existing dataset.",
@@ -522,7 +522,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   }),
   tool({
     name: "dataset_upload_video",
-    registrationGroup: "read",
+    registrationGroup: "write",
     stateChanging: true,
     description:
       "Upload a local video by extracting JPEG frames with ffmpeg, then start dataset ingest for an existing dataset.",
@@ -626,7 +626,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   }),
   tool({
     name: "training_monitor",
-    registrationGroup: "action",
+    registrationGroup: "read",
     stateChanging: false,
     description:
       "Report a model's training status and progress (works for private and public projects).",
@@ -668,7 +668,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   }),
   tool({
     name: "model_predict",
-    registrationGroup: "action",
+    registrationGroup: "read",
     stateChanging: false,
     description:
       "Run inference with a trained model on an image URL or base64 source (no local file paths).",
@@ -768,7 +768,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   }),
   tool({
     name: "exports_list",
-    registrationGroup: "write",
+    registrationGroup: "read",
     stateChanging: false,
     description: "List export jobs for a model.",
     inputSchema: {
@@ -791,7 +791,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   }),
   tool({
     name: "export_status",
-    registrationGroup: "write",
+    registrationGroup: "read",
     stateChanging: false,
     description: "Get status for one export job by 24-character export id.",
     inputSchema: {
@@ -1003,7 +1003,7 @@ export function registerReadTools(
   registerToolDefinitions(server, getClient, "read");
 }
 
-/** Register training monitor, predict, and download tools. */
+/** Register local action tools. */
 export function registerActionTools(
   server: McpServer,
   getClient: () => UltralyticsClient,
@@ -1011,7 +1011,7 @@ export function registerActionTools(
   registerToolDefinitions(server, getClient, "action");
 }
 
-/** Register export and training-start tools. The cost-incurring ones are guarded. */
+/** Register remote mutation tools. The cost-incurring ones are guarded. */
 export function registerWriteTools(
   server: McpServer,
   getClient: () => UltralyticsClient,

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,10 +1,15 @@
 import { readFileSync } from "node:fs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { afterEach, expect, test } from "vitest";
 
 import { createServer, SERVER_VERSION } from "../src/server.js";
-import { TOOL_NAMES, TOOL_SETS } from "../src/tools/index.js";
+import {
+  registerReadTools,
+  TOOL_NAMES,
+  TOOL_SETS,
+} from "../src/tools/index.js";
 
 const cleanups: Array<() => Promise<void>> = [];
 
@@ -16,6 +21,23 @@ afterEach(async () => {
     }
   }
 });
+
+async function listTools(server: McpServer) {
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  cleanups.push(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  const { tools } = await client.listTools();
+  return tools;
+}
 
 test("server version stays in sync with package.json", () => {
   const packageJson = JSON.parse(
@@ -40,24 +62,28 @@ test("tool taxonomy keeps write tools out of read-only set", () => {
   expect(overlap).toEqual([]);
 });
 
+test("registerReadTools registers only read-only tools", async () => {
+  const server = new McpServer({
+    name: "ultralytics-read-only",
+    version: SERVER_VERSION,
+  });
+
+  registerReadTools(server, () => {
+    throw new Error("client must not be created during tool listing");
+  });
+
+  const tools = await listTools(server);
+  expect(tools.map((tool) => tool.name).sort()).toEqual(
+    [...TOOL_SETS.readOnly].sort(),
+  );
+});
+
 test("server registers all available tools over the protocol", async () => {
   // A throwing client factory proves listing never constructs a client.
   const server = createServer(() => {
     throw new Error("client must not be created during tool listing");
   });
-  const client = new Client({ name: "test-client", version: "0.0.0" });
-  const [clientTransport, serverTransport] =
-    InMemoryTransport.createLinkedPair();
-
-  cleanups.push(async () => {
-    await client.close();
-    await server.close();
-  });
-
-  await server.connect(serverTransport);
-  await client.connect(clientTransport);
-
-  const { tools } = await client.listTools();
+  const tools = await listTools(server);
   const names = tools.map((tool) => tool.name).sort();
   expect(names).toEqual([...TOOL_NAMES].sort());
 


### PR DESCRIPTION
## Summary
Fix tool registration grouping so `registerReadTools()` exposes only read-only tools.

## Motivation
`registerReadTools()` was wiring up state-changing tools, which contradicted its API contract and could expose mutating operations to read-only consumers.

## Key Changes
- move state-changing project and dataset tools out of `read` registration
- move read-only monitor, predict, and export status/list tools into `read` registration
- add test asserting `registerReadTools()` matches `TOOL_SETS.readOnly` exactly