### PR TITLE
fix: harden model download writes

### DIFF
--- a/src/tools/downloads.ts
+++ b/src/tools/downloads.ts
@@ -2,9 +2,9 @@
  * fetch never forwards API credentials (handled by client.downloadBytes).
  */
 
-import { stat, writeFile } from "node:fs/promises";
+import { lstat, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 
 import type { UltralyticsClient } from "../client.js";
 import { resolveModel } from "../resolve.js";
@@ -80,6 +80,39 @@ async function statSafe(
   }
 }
 
+async function lstatSafe(
+  target: string,
+): Promise<{ exists: boolean; isDir: boolean; isSymlink: boolean }> {
+  try {
+    const info = await lstat(target);
+    return {
+      exists: true,
+      isDir: info.isDirectory(),
+      isSymlink: info.isSymbolicLink(),
+    };
+  } catch {
+    return { exists: false, isDir: false, isSymlink: false };
+  }
+}
+
+async function writeFileAtomic(
+  target: string,
+  content: Uint8Array,
+): Promise<void> {
+  const parent = dirname(target);
+  const temporary = join(
+    parent,
+    `.${basename(target)}.${process.pid}.${Date.now()}.tmp`,
+  );
+  try {
+    await writeFile(temporary, content, { flag: "wx" });
+    await rename(temporary, target);
+  } catch (error) {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
 async function downloadTarget(
   outputPath: string,
   overwrite: boolean,
@@ -98,9 +131,12 @@ async function downloadTarget(
     throw new Error(`Output parent is not a directory: ${parent}`);
   }
 
-  const targetInfo = await statSafe(target);
+  const targetInfo = await lstatSafe(target);
   if (targetInfo.exists && targetInfo.isDir) {
     throw new Error(`Output path is a directory: ${target}`);
+  }
+  if (targetInfo.exists && targetInfo.isSymlink) {
+    throw new Error(`Output path is a symbolic link: ${target}`);
   }
   if (targetInfo.exists && !overwrite) {
     throw new Error(
@@ -135,7 +171,7 @@ export async function modelDownload(
   }
 
   const content = await client.downloadBytes(signedUrl);
-  await writeFile(target, content);
+  await writeFileAtomic(target, content);
   return {
     summary: `Downloaded ${selectedName} to ${target} (${content.length} bytes).`,
     data: {

--- a/tests/tools/downloads.test.ts
+++ b/tests/tools/downloads.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -91,6 +91,22 @@ describe("modelDownload", () => {
     );
     // Untouched.
     expect(await readFile(outputPath, "utf8")).toBe("existing");
+  });
+
+  test("rejects symlink targets even when overwrite is enabled", async () => {
+    const { client } = downloadClient(
+      [{ name: "best.pt", url: "https://x/best.pt" }],
+      "weights",
+    );
+    const linkedPath = join(tmp, "linked.pt");
+    const outputPath = join(tmp, "best.pt");
+    await writeFile(linkedPath, "existing");
+    await symlink(linkedPath, outputPath);
+
+    await expect(
+      modelDownload(client, ID, { outputPath, overwrite: true }),
+    ).rejects.toThrow(/symbolic link/);
+    expect(await readFile(linkedPath, "utf8")).toBe("existing");
   });
 
   test("requires an existing parent directory", async () => {


### PR DESCRIPTION
## Summary
Harden `model_download` local file writes.

## Motivation
`model_download` accepted symlink output paths when `overwrite=true`, which could write downloaded model bytes through the link target.

## Key Changes
- reject symbolic-link output paths before writing
- write downloads to a temporary file in the target directory before renaming into place
- add a regression test that verifies symlink targets are rejected and left unchanged