### PR TITLE
docs: document local filesystem safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ See [TOOLS.md](./TOOLS.md) for full parameter reference, safety notes, local-pat
 - `training_start` requires `confirm_cost: true`
 - Ambiguous project or dataset refs fail instead of guessing
 - Signed upload and download URLs do not forward `Authorization`
+- Local upload tools read files from the MCP client host; approve calls only for paths you expect to share with Ultralytics
+- `model_download` writes to the requested local path; review `output_path` and `overwrite` before approving
 
 ## Troubleshooting
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -16,6 +16,8 @@ Auto-generated reference for Ultralytics Platform MCP tools.
 - `dataset_upload_folder` uploads a local image folder.
 - `dataset_upload_video` extracts frames from a local video file with `ffmpeg`.
 - `model_download` writes model weights to a local destination path.
+- Review local upload paths before approving tool calls; upload tools read from the MCP client host.
+- Review `model_download.output_path` and `overwrite` before approving downloads.
 
 ## Cost and Safety
 

--- a/scripts/generate-tools.mjs
+++ b/scripts/generate-tools.mjs
@@ -138,6 +138,8 @@ function renderSharedSections() {
     "- `dataset_upload_folder` uploads a local image folder.",
     "- `dataset_upload_video` extracts frames from a local video file with `ffmpeg`.",
     "- `model_download` writes model weights to a local destination path.",
+    "- Review local upload paths before approving tool calls; upload tools read from the MCP client host.",
+    "- Review `model_download.output_path` and `overwrite` before approving downloads.",
     "",
     "## Cost and Safety",
     "",


### PR DESCRIPTION
## Summary
Document local filesystem safety guidance for local-path tools.

## Motivation
Dataset upload tools read local files from the MCP client host, and `model_download` writes to a requested local path. Users should review those paths before approving tool calls.

## Key Changes
- add README safety guidance for local upload and download paths
- update the generated tools reference safety guidance
- keep `TOOLS.md` in sync by updating the generator source