### PR TITLE
feat: add model delete tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ See [TOOLS.md](./TOOLS.md) for full parameter reference, safety notes, local-pat
 
 - Projects: 5 tools
 - Datasets: 12 tools
-- Models: 4 tools
+- Models: 5 tools
 - Training: 2 tools
 - Exports: 3 tools
 - Infrastructure: 1 tool

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -274,7 +274,7 @@ Notes: Uses a local video path, extracts JPEG frames with ffmpeg, and starts ing
 
 ## Models
 
-4 tools.
+5 tools.
 
 ### models_list
 
@@ -291,6 +291,17 @@ Metadata: read-only
 Get one model by id, or by slug plus project.
 
 Metadata: read-only
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `model` | string | Yes | Model id, or slug when project is also provided. |
+| `project` | string | No | Project ref required when model is given by slug. |
+
+### models_delete
+
+Delete a model by id, or by slug plus project.
+
+Metadata: state-changing, destructive, non-idempotent
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |

--- a/fixtures/parity/models_delete.json
+++ b/fixtures/parity/models_delete.json
@@ -1,0 +1,65 @@
+{
+  "tool": "models_delete",
+  "args": {
+    "model": "exp",
+    "project": "user/road"
+  },
+  "api": [
+    {
+      "method": "GET",
+      "path": "/api/projects",
+      "query": {
+        "username": "user"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "projects": [
+            {
+              "_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+              "slug": "road",
+              "username": "user"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/models",
+      "query": {
+        "projectId": "aaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "response": {
+        "status": 200,
+        "json": {
+          "models": [
+            {
+              "_id": "cccccccccccccccccccccccc",
+              "slug": "exp"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/models/cccccccccccccccccccccccc",
+      "response": {
+        "status": 200,
+        "json": {
+          "success": true
+        }
+      }
+    }
+  ],
+  "expected": {
+    "summary": "Deleted model cccccccccccccccccccccccc.",
+    "data": {
+      "id": "cccccccccccccccccccccccc",
+      "response": {
+        "success": true
+      }
+    }
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -28,7 +28,7 @@ import {
 import { modelDownload } from "./downloads.js";
 import { exportCreate, exportStatus, exportsList } from "./exports.js";
 import { gpuAvailability } from "./gpu.js";
-import { modelsGet, modelsList } from "./models.js";
+import { modelsDelete, modelsGet, modelsList } from "./models.js";
 import { modelPredict } from "./predict.js";
 import {
   exploreProjects,
@@ -56,7 +56,7 @@ export {
 export { modelDownload } from "./downloads.js";
 export { exportCreate, exportStatus, exportsList } from "./exports.js";
 export { gpuAvailability } from "./gpu.js";
-export { modelsGet, modelsList } from "./models.js";
+export { modelsDelete, modelsGet, modelsList } from "./models.js";
 export { modelPredict } from "./predict.js";
 export {
   exploreProjects,
@@ -604,6 +604,36 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
       async ({ model, project }) =>
         toMcpTextResult(
           await modelsGet(
+            getClient(),
+            model as string,
+            project as string | undefined,
+          ),
+        ),
+  }),
+  tool({
+    name: "models_delete",
+    registrationGroup: "write",
+    stateChanging: true,
+    description: "Delete a model by id, or by slug plus project.",
+    inputSchema: {
+      model: z
+        .string()
+        .describe("Model id, or slug when project is also provided."),
+      project: z
+        .string()
+        .optional()
+        .describe("Project ref required when model is given by slug."),
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+    },
+    createHandler:
+      (getClient) =>
+      async ({ model, project }) =>
+        toMcpTextResult(
+          await modelsDelete(
             getClient(),
             model as string,
             project as string | undefined,

--- a/src/tools/models.ts
+++ b/src/tools/models.ts
@@ -1,4 +1,4 @@
-/** Read-only model tools. */
+/** Model tools. */
 
 import type { UltralyticsClient } from "../client.js";
 import { resolveModel, resolveProject } from "../resolve.js";
@@ -41,5 +41,19 @@ export async function modelsGet(
       `Model '${pyField(fields.name)}' [${pyField(fields.task)}] status=${pyField(fields.status)}, ` +
       `epochs=${pyField(fields.epochs)}, params=${pyField(info.parameters)}.`,
     data: item,
+  };
+}
+
+/** Delete a model by id, or by slug within a project. */
+export async function modelsDelete(
+  client: UltralyticsClient,
+  model: string,
+  project?: string,
+): Promise<NormalizedToolResult> {
+  const modelId = await resolveModel(client, model, project);
+  const data = await client.delete(`/models/${modelId}`);
+  return {
+    summary: `Deleted model ${modelId}.`,
+    data: { id: modelId, response: data },
   };
 }

--- a/tests/parity-fixtures.test.ts
+++ b/tests/parity-fixtures.test.ts
@@ -23,6 +23,7 @@ import {
   exploreDatasets,
   exploreProjects,
   modelDownload,
+  modelsDelete,
   modelsGet,
   projectsCreate,
   projectsDelete,
@@ -259,6 +260,12 @@ const TOOL_RUNNERS: Record<
     projectsDelete(client, args.project as string),
   models_get: (client, args) =>
     modelsGet(client, args.model as string, args.project as string | undefined),
+  models_delete: (client, args) =>
+    modelsDelete(
+      client,
+      args.model as string,
+      args.project as string | undefined,
+    ),
   training_monitor: (client, args) =>
     trainingMonitor(
       client,
@@ -313,6 +320,7 @@ describe("parity fixtures", () => {
         "dataset_upload_folder.json",
         "dataset_upload_video.json",
         "models_get.json",
+        "models_delete.json",
         "projects_create.json",
         "projects_delete.json",
         "projects_list.json",

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -119,6 +119,14 @@ test("server registers all available tools over the protocol", async () => {
   const datasetsDelete = tools.find((tool) => tool.name === "datasets_delete");
   expect(datasetsDelete?.inputSchema?.required).toEqual(["dataset"]);
 
+  const modelsDelete = tools.find((tool) => tool.name === "models_delete");
+  expect(modelsDelete?.inputSchema?.required).toEqual(["model"]);
+  expect(modelsDelete?.annotations).toMatchObject({
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+  });
+
   const datasetImagesList = tools.find(
     (tool) => tool.name === "dataset_images_list",
   );

--- a/tests/tools/models.test.ts
+++ b/tests/tools/models.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { modelsGet, modelsList } from "../../src/tools/models.js";
+import { modelsDelete, modelsGet, modelsList } from "../../src/tools/models.js";
 import { jsonResponse, routeClient } from "../helpers.js";
 
 describe("modelsList", () => {
@@ -86,5 +86,56 @@ describe("modelsGet", () => {
     expect(result.summary).toBe(
       "Model 'None' [None] status=None, epochs=None, params=None.",
     );
+  });
+});
+
+describe("modelsDelete", () => {
+  test("deletes a model by id", async () => {
+    const id = "a".repeat(24);
+    const { client, calls } = routeClient((path) => {
+      if (path === `/api/models/${id}`) {
+        return jsonResponse({ success: true });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const result = await modelsDelete(client, id);
+
+    expect(result.summary).toBe(`Deleted model ${id}.`);
+    expect(result.data).toEqual({
+      id,
+      response: { success: true },
+    });
+    expect(calls[0].path).toBe(`/api/models/${id}`);
+  });
+
+  test("resolves slug plus project before deleting", async () => {
+    const projectId = "b".repeat(24);
+    const modelId = "c".repeat(24);
+    const { client, calls } = routeClient((path, params) => {
+      if (path === "/api/projects" && params.get("username") === "user") {
+        return jsonResponse({
+          projects: [{ _id: projectId, slug: "proj", username: "user" }],
+        });
+      }
+      if (path === "/api/models" && params.get("projectId") === projectId) {
+        return jsonResponse({
+          models: [{ _id: modelId, slug: "exp" }],
+        });
+      }
+      if (path === `/api/models/${modelId}`) {
+        return jsonResponse({ success: true });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const result = await modelsDelete(client, "exp", "user/proj");
+
+    expect(result.summary).toBe(`Deleted model ${modelId}.`);
+    expect(calls.map((call) => call.path)).toEqual([
+      "/api/projects",
+      "/api/models",
+      `/api/models/${modelId}`,
+    ]);
   });
 });


### PR DESCRIPTION
- Summary
Add a models_delete tool for removing models by id or slug plus project.

- Motivation
Training failures can leave orphan model shells, and the MCP had no way to clean them up.

- Key Changes
Register models_delete as a destructive write tool, add parity and unit coverage, and update generated tool docs.