### PR TITLE
fix: resolve datasets by username first

### DIFF
--- a/fixtures/parity/dataset_export.json
+++ b/fixtures/parity/dataset_export.json
@@ -9,7 +9,6 @@
       "method": "GET",
       "path": "/api/datasets",
       "query": {
-        "slug": "data",
         "username": "user"
       },
       "response": {

--- a/fixtures/parity/dataset_images_list.json
+++ b/fixtures/parity/dataset_images_list.json
@@ -15,7 +15,6 @@
       "method": "GET",
       "path": "/api/datasets",
       "query": {
-        "slug": "data",
         "username": "user"
       },
       "response": {

--- a/fixtures/parity/dataset_ingest.json
+++ b/fixtures/parity/dataset_ingest.json
@@ -10,7 +10,6 @@
       "method": "GET",
       "path": "/api/datasets",
       "query": {
-        "slug": "data",
         "username": "user"
       },
       "response": {

--- a/fixtures/parity/dataset_upload_file.json
+++ b/fixtures/parity/dataset_upload_file.json
@@ -10,7 +10,6 @@
       "method": "GET",
       "path": "/api/datasets",
       "query": {
-        "slug": "data",
         "username": "user"
       },
       "response": {

--- a/fixtures/parity/dataset_upload_folder.json
+++ b/fixtures/parity/dataset_upload_folder.json
@@ -14,7 +14,6 @@
       "method": "GET",
       "path": "/api/datasets",
       "query": {
-        "slug": "data",
         "username": "user"
       },
       "response": {

--- a/fixtures/parity/dataset_upload_video.json
+++ b/fixtures/parity/dataset_upload_video.json
@@ -12,7 +12,6 @@
       "method": "GET",
       "path": "/api/datasets",
       "query": {
-        "slug": "data",
         "username": "user"
       },
       "response": {

--- a/fixtures/parity/dataset_version_create.json
+++ b/fixtures/parity/dataset_version_create.json
@@ -9,7 +9,6 @@
       "method": "GET",
       "path": "/api/datasets",
       "query": {
-        "slug": "data",
         "username": "user"
       },
       "response": {

--- a/fixtures/parity/datasets_delete.json
+++ b/fixtures/parity/datasets_delete.json
@@ -8,7 +8,6 @@
       "method": "GET",
       "path": "/api/datasets",
       "query": {
-        "slug": "data",
         "username": "user"
       },
       "response": {

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -170,11 +170,10 @@ export async function resolveDataset(
     [username, slug] = simpleUsernameSlug(parts, "dataset", ref);
   }
 
-  const params: Record<string, string> = { slug };
-  if (username) {
-    params.username = username;
-  }
-  const data = await client.get("/datasets", params);
+  const data = await client.get(
+    "/datasets",
+    username ? { username } : undefined,
+  );
   const matches = listField(data, "datasets").filter(
     (dataset) =>
       dataset.slug === slug &&

--- a/tests/resolve.test.ts
+++ b/tests/resolve.test.ts
@@ -121,7 +121,47 @@ describe("resolveProject", () => {
 });
 
 describe("resolveDataset", () => {
-  test("resolves a dataset ul:// URI with slug and username params", async () => {
+  test("resolves a dataset ul:// URI by querying username and filtering slug locally", async () => {
+    const { client, calls } = clientWith(
+      () =>
+        new Response(
+          JSON.stringify({
+            datasets: [
+              { _id: "x".repeat(24), slug: "other", username: "u" },
+              { _id: "d".repeat(24), slug: "data", username: "u" },
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
+    expect(await resolveDataset(client, "ul://u/datasets/data")).toBe(
+      "d".repeat(24),
+    );
+    expect(calls[0].path).toBe("/api/datasets");
+    expect(calls[0].params.get("username")).toBe("u");
+    expect(calls[0].params.has("slug")).toBe(false);
+  });
+
+  test("resolves username/slug by querying username and filtering slug locally", async () => {
+    const { client, calls } = clientWith(
+      () =>
+        new Response(
+          JSON.stringify({
+            datasets: [
+              { _id: "x".repeat(24), slug: "other", username: "u" },
+              { _id: "d".repeat(24), slug: "data", username: "u" },
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
+    expect(await resolveDataset(client, "u/data")).toBe("d".repeat(24));
+    expect(calls[0].path).toBe("/api/datasets");
+    expect(calls[0].params.get("username")).toBe("u");
+    expect(calls[0].params.has("slug")).toBe(false);
+  });
+
+  test("resolves a bare dataset slug without sending a slug query", async () => {
     const { client, calls } = clientWith(
       () =>
         new Response(
@@ -131,12 +171,10 @@ describe("resolveDataset", () => {
           { status: 200 },
         ),
     );
-    expect(await resolveDataset(client, "ul://u/datasets/data")).toBe(
-      "d".repeat(24),
-    );
+    expect(await resolveDataset(client, "data")).toBe("d".repeat(24));
     expect(calls[0].path).toBe("/api/datasets");
-    expect(calls[0].params.get("slug")).toBe("data");
-    expect(calls[0].params.get("username")).toBe("u");
+    expect(calls[0].params.has("slug")).toBe(false);
+    expect(calls[0].params.has("username")).toBe(false);
   });
 
   test("a malformed dataset ul:// URI is rejected", async () => {

--- a/tests/tools/datasets.test.ts
+++ b/tests/tools/datasets.test.ts
@@ -880,7 +880,7 @@ describe("datasetUploadFile", () => {
     });
 
     expect(calls.map((call) => call.url)).toEqual([
-      `${BASE}/datasets?slug=data&username=user`,
+      `${BASE}/datasets?username=user`,
       `${BASE}/upload/signed-url`,
       `${BASE}/upload/complete`,
       `${BASE}/datasets/ingest`,


### PR DESCRIPTION
- Summary
Make dataset ref resolution query by username first and filter slug locally.

- Motivation
Dataset username/slug lookup could fail when the API did not return matches for slug-filtered requests.

- Key Changes
Mirror project resolution behavior for datasets, add regression coverage for username/slug refs, and update parity fixtures for username-only dataset queries.