### PR TITLE
fix: match model downloads by signed url path

### DIFF
--- a/fixtures/parity/model_download_signed_url.json
+++ b/fixtures/parity/model_download_signed_url.json
@@ -18,8 +18,8 @@
               "url": "https://signed.example/last.pt"
             },
             {
-              "name": "best.pt",
-              "url": "https://signed.example/best.pt"
+              "name": "exp-4.pt",
+              "downloadUrl": "https://signed.example/models/aaaaaaaaaaaaaaaaaaaaaaaa/best.pt?download=1"
             }
           ]
         }
@@ -27,14 +27,14 @@
     }
   ],
   "download": {
-    "url": "https://signed.example/best.pt",
+    "url": "https://signed.example/models/aaaaaaaaaaaaaaaaaaaaaaaa/best.pt?download=1",
     "body_text": "weights"
   },
   "expected": {
-    "summary": "Downloaded best.pt to __TMP__/best.pt (7 bytes).",
+    "summary": "Downloaded exp-4.pt to __TMP__/best.pt (7 bytes).",
     "data": {
       "modelId": "aaaaaaaaaaaaaaaaaaaaaaaa",
-      "filename": "best.pt",
+      "filename": "exp-4.pt",
       "path": "__TMP__/best.pt",
       "bytes": 7
     }

--- a/src/tools/downloads.ts
+++ b/src/tools/downloads.ts
@@ -22,6 +22,42 @@ function fileUrl(info: Record<string, unknown>): string | null {
   return value ? String(value) : null;
 }
 
+function urlPathBasename(info: Record<string, unknown>): string | null {
+  const url = fileUrl(info);
+  if (url === null) {
+    return null;
+  }
+  try {
+    return basename(new URL(url).pathname);
+  } catch {
+    return null;
+  }
+}
+
+function fileMatchesName(
+  file: Record<string, unknown>,
+  filename: string,
+): boolean {
+  const name = fileName(file);
+  const requested = basename(filename);
+  if (name !== null && (name === filename || basename(name) === requested)) {
+    return true;
+  }
+  return urlPathBasename(file) === requested;
+}
+
+function availableFileNames(files: Record<string, unknown>[]): string {
+  return files
+    .map((file) => {
+      const name = fileName(file) ?? "unknown";
+      const urlName = urlPathBasename(file);
+      return urlName && urlName !== basename(name)
+        ? `${name} (url: ${urlName})`
+        : name;
+    })
+    .join(", ");
+}
+
 function modelFiles(data: unknown): Record<string, unknown>[] {
   const record = asRecord(data);
   const files = record.files ?? record.modelFiles ?? record.models;
@@ -43,16 +79,21 @@ function selectModelFile(
   }
   if (filename) {
     for (const file of files) {
-      if (fileName(file) === filename) {
+      if (fileMatchesName(file, filename)) {
         return file;
       }
     }
     throw new Error(
-      `No model file named '${filename}' was returned by the API.`,
+      `No model file matching '${filename}'. Available: ${availableFileNames(files)}.`,
     );
   }
   for (const file of files) {
-    if (fileName(file) === "best.pt") {
+    if (urlPathBasename(file) === "best.pt") {
+      return file;
+    }
+  }
+  for (const file of files) {
+    if (basename(fileName(file) ?? "") === "best.pt") {
       return file;
     }
   }

--- a/tests/tools/downloads.test.ts
+++ b/tests/tools/downloads.test.ts
@@ -21,10 +21,7 @@ afterEach(async () => {
 });
 
 /** Client with a files endpoint and a recorded signed-URL download fetch. */
-function downloadClient(
-  files: Array<{ name: string; url: string }>,
-  body: string,
-) {
+function downloadClient(files: Array<Record<string, unknown>>, body: string) {
   const downloadCalls: { url: string; auth: string | undefined }[] = [];
   const fetchImpl = (async (url: string | URL) => {
     if (String(url).endsWith(`/models/${ID}/files`)) {
@@ -76,6 +73,102 @@ describe("modelDownload", () => {
     expect(downloadCalls[0].url).toBe("https://signed.example/best.pt");
     expect(downloadCalls[0].auth).toBeUndefined();
     expect(await readFile(outputPath, "utf8")).toBe("weights");
+  });
+
+  test("matches requested filename against the signed URL path basename", async () => {
+    const { client, downloadCalls } = downloadClient(
+      [
+        {
+          name: "exp-4.pt",
+          downloadUrl: "https://signed.example/models/abc/best.pt?x=1",
+        },
+      ],
+      "weights",
+    );
+    const outputPath = join(tmp, "best.pt");
+
+    const result = await modelDownload(client, ID, {
+      outputPath,
+      filename: "best.pt",
+    });
+
+    expect(result.summary).toBe(
+      `Downloaded exp-4.pt to ${outputPath} (7 bytes).`,
+    );
+    expect(result.data).toEqual({
+      modelId: ID,
+      filename: "exp-4.pt",
+      path: outputPath,
+      bytes: 7,
+    });
+    expect(downloadCalls[0].url).toBe(
+      "https://signed.example/models/abc/best.pt?x=1",
+    );
+  });
+
+  test("selects by friendly model filename before signed URL path basename", async () => {
+    const { client, downloadCalls } = downloadClient(
+      [
+        {
+          name: "exp-4.pt",
+          downloadUrl: "https://signed.example/models/abc/best.pt",
+        },
+      ],
+      "weights",
+    );
+    const outputPath = join(tmp, "exp-4.pt");
+
+    await modelDownload(client, ID, {
+      outputPath,
+      filename: "exp-4.pt",
+    });
+
+    expect(downloadCalls[0].url).toBe(
+      "https://signed.example/models/abc/best.pt",
+    );
+  });
+
+  test("prefers best.pt from signed URL path when no filename is requested", async () => {
+    const { client, downloadCalls } = downloadClient(
+      [
+        {
+          name: "last.pt",
+          downloadUrl: "https://signed.example/models/abc/last.pt",
+        },
+        {
+          name: "exp-4.pt",
+          downloadUrl: "https://signed.example/models/abc/best.pt",
+        },
+      ],
+      "weights",
+    );
+    const outputPath = join(tmp, "best.pt");
+
+    await modelDownload(client, ID, { outputPath });
+
+    expect(downloadCalls[0].url).toBe(
+      "https://signed.example/models/abc/best.pt",
+    );
+  });
+
+  test("lists file names and URL basenames when requested filename is missing", async () => {
+    const { client } = downloadClient(
+      [
+        {
+          name: "exp-4.pt",
+          downloadUrl: "https://signed.example/models/abc/best.pt",
+        },
+        { name: "last.pt", downloadUrl: "not a url" },
+      ],
+      "weights",
+    );
+    const outputPath = join(tmp, "missing.pt");
+
+    await expect(
+      modelDownload(client, ID, { outputPath, filename: "missing.pt" }),
+    ).rejects.toThrow(
+      /No model file matching 'missing.pt'. Available: exp-4.pt \(url: best.pt\), last.pt/,
+    );
   });
 
   test("refuses to overwrite an existing file by default", async () => {


### PR DESCRIPTION
- Summary
Make model_download match requested filenames against signed URL path basenames.

- Motivation
The API can expose friendly file names like exp-4.pt while the canonical best weights live at a signed URL path ending in best.pt.

- Key Changes
Match exact names, file basenames, and signed URL path basenames; prefer URL best.pt by default; add regression and parity coverage.