### PR TITLE
docs: document platform ingest behaviors

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ See [TOOLS.md](./TOOLS.md) for full parameter reference, safety notes, local-pat
 - Signed upload and download URLs do not forward `Authorization`
 - Local upload tools read files from the MCP client host; approve calls only for paths you expect to share with Ultralytics
 - `model_download` writes to the requested local path; review `output_path` and `overwrite` before approving
+- Re-uploading labeled copies may duplicate dataset image records instead of attaching labels to existing images
+- Images-only dataset uploads may be inferred as `classify`; include labels when task preservation matters
 
 ## Troubleshooting
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -25,6 +25,11 @@ Auto-generated reference for Ultralytics Platform MCP tools.
 - `export_create` requires `confirm_cost=true` and starts a credit-costing export job.
 - `projects_delete` and `datasets_delete` are soft-delete operations.
 
+## Platform Behaviors
+
+- Re-uploading images with label files can create new dataset image records instead of attaching labels to existing images. To label existing images, edit them on the platform; re-uploading labeled copies may duplicate image records.
+- Images-only dataset uploads may be inferred as `classify` by the platform even when the dataset was created for detection. Include labels in a task-specific archive when task preservation matters.
+
 ## Projects
 
 5 tools.
@@ -232,7 +237,7 @@ Metadata: state-changing, non-idempotent
 | `folder_path` | string | Yes | Local path to image folder. |
 | `targetSplit` | string | No |  |
 
-Notes: Uses a local image folder path, zips it client-side, and starts ingest into an existing dataset.
+Notes: Uses a local image folder path, zips it client-side, and starts ingest into an existing dataset. Images-only uploads may be inferred as classify by the platform; include task-specific labels when task preservation matters.
 
 #### Upload image folder
 

--- a/scripts/generate-tools.mjs
+++ b/scripts/generate-tools.mjs
@@ -147,6 +147,11 @@ function renderSharedSections() {
     "- `export_create` requires `confirm_cost=true` and starts a credit-costing export job.",
     "- `projects_delete` and `datasets_delete` are soft-delete operations.",
     "",
+    "## Platform Behaviors",
+    "",
+    "- Re-uploading images with label files can create new dataset image records instead of attaching labels to existing images. To label existing images, edit them on the platform; re-uploading labeled copies may duplicate image records.",
+    "- Images-only dataset uploads may be inferred as `classify` by the platform even when the dataset was created for detection. Include labels in a task-specific archive when task preservation matters.",
+    "",
   ].join("\n");
 }
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -498,7 +498,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
       idempotentHint: false,
     },
     docNote:
-      "Uses a local image folder path, zips it client-side, and starts ingest into an existing dataset.",
+      "Uses a local image folder path, zips it client-side, and starts ingest into an existing dataset. Images-only uploads may be inferred as classify by the platform; include task-specific labels when task preservation matters.",
     examples: [
       {
         title: "Upload image folder",

--- a/tests/generate-tools.test.ts
+++ b/tests/generate-tools.test.ts
@@ -21,6 +21,9 @@ describe("generate-tools script", () => {
     expect(output).toContain("# Tools Reference");
     expect(output).toContain("Auto-generated. Do not edit by hand.");
     expect(output).toContain("## Conventions");
+    expect(output).toContain("## Platform Behaviors");
+    expect(output).toContain("new dataset image records");
+    expect(output).toContain("classify");
     expect(output).toContain("## Projects");
     expect(output).toContain("## Datasets");
     expect(output).toContain("## Models");


### PR DESCRIPTION
- Summary
Document platform ingest behavior for re-uploaded labels and images-only uploads.

- Motivation
Dataset ingest can duplicate labeled image copies and infer images-only uploads as classify, which affects annotation and training workflows.

- Key Changes
Add platform behavior notes to generated tool docs, README safety notes, and generator coverage.