### PR TITLE
docs: add demo video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ dataset uploads.
 > [!IMPORTANT]
 > Independent community project. Not affiliated with or endorsed by Ultralytics.
 
+## Demo
+
+https://github.com/user-attachments/assets/cc927af9-0211-41f1-9054-eb9c74578f34
+
 ---
 
 ## Table of Contents


### PR DESCRIPTION
## Summary

Add a demo video to the top of the README so the project's capabilities are visible above the fold.