### PR TITLE
chore: add MCP registry manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ultralytics-mcp",
+  "mcpName": "io.github.amanharshx/ultralytics-mcp",
   "version": "0.1.8",
   "description": "MCP for Ultralytics Platform workflows, datasets, training, prediction, and model operations.",
   "type": "module",
@@ -9,6 +10,7 @@
   "files": [
     "dist",
     "README.md",
+    "server.json",
     "TOOLS.md",
     "package.json"
   ],

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const [, , version, targetDir = "."] = process.argv;
@@ -18,3 +19,18 @@ execFileSync(
     stdio: "inherit",
   },
 );
+
+const serverJsonPath = resolve(targetDir, "server.json");
+
+if (existsSync(serverJsonPath)) {
+  const serverJson = JSON.parse(readFileSync(serverJsonPath, "utf8"));
+  serverJson.version = version;
+
+  if (Array.isArray(serverJson.packages)) {
+    for (const packageEntry of serverJson.packages) {
+      packageEntry.version = version;
+    }
+  }
+
+  writeFileSync(serverJsonPath, `${JSON.stringify(serverJson, null, 2)}\n`);
+}

--- a/server.json
+++ b/server.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.amanharshx/ultralytics-mcp",
+  "title": "Ultralytics Platform MCP",
+  "description": "MCP server for Ultralytics Platform projects, datasets, training, prediction, exports, and models.",
+  "version": "0.1.8",
+  "websiteUrl": "https://github.com/amanharshx/ultralytics-mcp#readme",
+  "repository": {
+    "url": "https://github.com/amanharshx/ultralytics-mcp",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "ultralytics-mcp",
+      "version": "0.1.8",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "ULTRALYTICS_API_KEY",
+          "description": "Ultralytics Platform API key.",
+          "isRequired": true,
+          "isSecret": true,
+          "placeholder": "ul_your_api_key_here"
+        },
+        {
+          "name": "ULTRALYTICS_API_BASE",
+          "description": "Optional Ultralytics API base URL override.",
+          "isRequired": false,
+          "placeholder": "https://platform.ultralytics.com/api"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/server-json.test.ts
+++ b/tests/server-json.test.ts
@@ -1,0 +1,54 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const packageJsonPath = resolve(repoRoot, "package.json");
+const serverJsonPath = resolve(repoRoot, "server.json");
+
+type PackageJson = {
+  mcpName?: string;
+  name: string;
+  version: string;
+};
+
+type ServerJson = {
+  name: string;
+  packages: Array<{
+    identifier: string;
+    registryType: string;
+    transport: { type: string };
+    version: string;
+  }>;
+  version: string;
+};
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+describe("MCP registry manifest", () => {
+  test("uses matching package and server identity", () => {
+    expect(existsSync(serverJsonPath)).toBe(true);
+
+    const packageJson = readJson<PackageJson>(packageJsonPath);
+    const serverJson = readJson<ServerJson>(serverJsonPath);
+
+    expect(packageJson.mcpName).toBe("io.github.amanharshx/ultralytics-mcp");
+    expect(serverJson.name).toBe(packageJson.mcpName);
+    expect(serverJson.packages).toHaveLength(1);
+    expect(serverJson.packages[0]?.identifier).toBe(packageJson.name);
+    expect(serverJson.packages[0]?.registryType).toBe("npm");
+    expect(serverJson.packages[0]?.transport.type).toBe("stdio");
+  });
+
+  test("keeps registry manifest versions aligned with package version", () => {
+    expect(existsSync(serverJsonPath)).toBe(true);
+
+    const packageJson = readJson<PackageJson>(packageJsonPath);
+    const serverJson = readJson<ServerJson>(serverJsonPath);
+
+    expect(serverJson.version).toBe(packageJson.version);
+    expect(serverJson.packages[0]?.version).toBe(packageJson.version);
+  });
+});

--- a/tests/version-bump-script.test.ts
+++ b/tests/version-bump-script.test.ts
@@ -19,13 +19,34 @@ test("version bump script repairs nested lockfile version on same-version rerun"
 
   const packageJsonPath = join(dir, "package.json");
   const packageLockPath = join(dir, "package-lock.json");
+  const serverJsonPath = join(dir, "server.json");
 
   writeFileSync(
     packageJsonPath,
     JSON.stringify(
       {
         name: "fixture-package",
+        mcpName: "io.github.example/fixture-package",
         version: "0.1.4",
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    serverJsonPath,
+    JSON.stringify(
+      {
+        name: "io.github.example/fixture-package",
+        version: "0.1.3",
+        packages: [
+          {
+            registryType: "npm",
+            identifier: "fixture-package",
+            version: "0.1.3",
+            transport: { type: "stdio" },
+          },
+        ],
       },
       null,
       2,
@@ -62,8 +83,16 @@ test("version bump script repairs nested lockfile version on same-version rerun"
     version: string;
     packages: { "": { version: string } };
   };
+  const updatedServerJson = JSON.parse(
+    readFileSync(serverJsonPath, "utf8"),
+  ) as {
+    version: string;
+    packages: Array<{ version: string }>;
+  };
 
   expect(updatedPackageJson.version).toBe("0.1.4");
   expect(updatedLockfile.version).toBe("0.1.4");
   expect(updatedLockfile.packages[""].version).toBe("0.1.4");
+  expect(updatedServerJson.version).toBe("0.1.4");
+  expect(updatedServerJson.packages[0]?.version).toBe("0.1.4");
 });


### PR DESCRIPTION
## Summary
Add MCP registry metadata for the npm package.

## Motivation
Make the server ready for MCP registry discovery and keep registry metadata aligned with package releases.

## Key Changes
- add `server.json` with npm stdio package metadata
- add `mcpName` and include `server.json` in package files
- sync `server.json` versions in the bump script
- add tests for registry identity and version alignment