### PR TITLE
docs: add community health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,65 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in this
+project a harassment-free experience for everyone, regardless of age, body size,
+visible or invisible disability, ethnicity, sex characteristics, gender identity
+and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints, experience levels, and backgrounds
+- Gracefully accepting constructive feedback
+- Focusing on what is best for the project and its users
+- Showing empathy toward other community members
+
+Examples of unacceptable behavior:
+
+- Harassment, threats, or personal or political attacks
+- Sexualized language or imagery, or unwelcome sexual attention
+- Trolling, insulting or derogatory comments, or sustained disruption
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct that could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Maintainers are responsible for clarifying and enforcing these standards. They
+may remove, edit, or reject comments, commits, code, issues, pull requests, and
+other contributions that are not aligned with this Code of Conduct, and may
+temporarily or permanently ban any contributor for behavior they deem
+inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — including the
+repository, issues, pull requests, and discussions — and also applies when an
+individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers by opening a minimal public issue that requests
+maintainer contact. Do not include private personal information in public
+reports; sensitive details can be shared once a private channel is established.
+
+All complaints will be reviewed and investigated promptly and fairly.
+Maintainers are obligated to respect the privacy and security of anyone who
+reports an incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing
+
+Thanks for your interest in improving this project. This guide covers the setup,
+workflow, and conventions used here.
+
+## Prerequisites
+
+- Node.js `>=20`
+- `ffmpeg` and `ffprobe` on your `PATH` (only needed to work on the video upload
+  tool)
+
+## Setup
+
+```bash
+npm install
+npm run build
+npm test
+```
+
+## Development Workflow
+
+Keep public wording product-facing. Describe what a change does for users rather
+than framing it as a port, mirror, or rewrite.
+
+If a change affects user-facing tools, arguments, safety behavior, or examples,
+update `README.md` and regenerate the tool reference:
+
+```bash
+npm run generate:tools
+```
+
+Commit the regenerated `TOOLS.md`; CI fails if it is out of date.
+
+## Verification
+
+Run the full check suite before opening a pull request:
+
+```bash
+npm run check   # lint and format
+npm test        # unit and integration tests
+npm run build   # type-check and compile
+```
+
+## Registry Metadata
+
+The npm package and the MCP registry manifest must stay aligned. These five
+values are expected to match on every release:
+
+- `package.json` → `mcpName`
+- `server.json` → `name`
+- `package.json` → `version`
+- `server.json` → top-level `version`
+- `server.json` → `packages[].version`
+
+Always update versions through the bump script so package and registry metadata
+move together:
+
+```bash
+node scripts/bump-version.mjs <version>
+```
+
+A test guards this alignment and will fail if the values drift.
+
+## Pull Requests
+
+Use a short, [conventional](https://www.conventionalcommits.org) title:
+
+```text
+feat: add dataset upload video tool
+```
+
+Keep the description focused:
+
+```markdown
+## Summary
+
+## Motivation
+
+## Key Changes
+```
+
+## Code of Conduct
+
+By participating in this project, you agree to abide by the
+[Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes target the latest published release on npm. Older versions are not
+maintained; please upgrade to the latest release before reporting an issue.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.
+
+Instead, use GitHub private vulnerability reporting:
+
+1. Open the repository **Security** tab.
+2. Select **Report a vulnerability**.
+3. Provide enough detail to reproduce and assess the impact.
+
+If private reporting is unavailable, open a minimal public issue requesting a
+private contact channel and withhold sensitive details until that channel is
+established.
+
+### What to Include
+
+- Affected version
+- A clear description of the issue and its impact
+- Step-by-step reproduction instructions
+- Any relevant logs or tool call transcripts, with secrets removed
+
+## Handling Sensitive Data
+
+This project works with API keys, signed upload and download URLs, and local
+file paths. When preparing a report, never include real API keys, signed URLs,
+private dataset contents, or private model artifacts. Redact or replace any
+sensitive values with placeholders.
+
+## Response Process
+
+- **Acknowledgment:** within 72 hours of a report
+- **Status update:** within one week
+- **Resolution:** a fix is released as soon as reasonably possible, prioritized
+  by severity
+
+We will keep you informed throughout the process and credit reporters who wish
+to be acknowledged once a fix is released.
+
+## Scope
+
+This is an independent community project. It is not affiliated with, maintained
+by, or endorsed by Ultralytics.


### PR DESCRIPTION
## Summary
Add community health documentation for contributors and security reports.

## Motivation
Make contribution, security reporting, and conduct expectations clear for the public repository.

## Key Changes
- add security reporting policy and response process
- add contributor setup, verification, and PR guidance
- add project code of conduct