### PR TITLE
ci: include registry manifest in release bump

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -69,6 +69,7 @@ jobs:
           ## Key Changes
           - bump `package.json` to ${{ steps.version.outputs.next_version }}
           - bump `package-lock.json` to ${{ steps.version.outputs.next_version }}
+          - bump `server.json` to ${{ steps.version.outputs.next_version }}
           - prepare main for tag ${{ steps.version.outputs.next_tag }}
           EOF
           )
@@ -81,7 +82,7 @@ jobs:
 
           node scripts/bump-version.mjs "${{ steps.version.outputs.next_version }}"
 
-          git add package.json package-lock.json
+          git add package.json package-lock.json server.json
           git commit -m "chore: bump version to ${{ steps.version.outputs.next_tag }}"
           git push -f -u origin "$BRANCH"
 


### PR DESCRIPTION
## Summary
Include `server.json` in automated release bump PRs.

## Motivation
Release bumps update registry metadata through the bump script, but the workflow only staged package files, leaving `server.json` out of the generated PR.

## Key Changes
- include `server.json` in the release bump PR summary
- stage `server.json` when committing automated version bumps