### PR TITLE
chore: bump version to v0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ultralytics-mcp",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ultralytics-mcp",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ultralytics-mcp",
   "mcpName": "io.github.amanharshx/ultralytics-mcp",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "MCP for Ultralytics Platform workflows, datasets, training, prediction, and model operations.",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.amanharshx/ultralytics-mcp",
   "title": "Ultralytics Platform MCP",
   "description": "MCP server for Ultralytics Platform projects, datasets, training, prediction, exports, and models.",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "websiteUrl": "https://github.com/amanharshx/ultralytics-mcp#readme",
   "repository": {
     "url": "https://github.com/amanharshx/ultralytics-mcp",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "ultralytics-mcp",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
Prepare the next patch release version bump.

## Motivation
Keep package version and release tag creation in a repeatable manual workflow.

## Key Changes
- bump `package.json` to 0.1.9
- bump `package-lock.json` to 0.1.9
- bump `server.json` to 0.1.9
- prepare main for tag v0.1.9