### PR TITLE
fix: preserve labels on named dataset archive ingests

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -213,7 +213,7 @@ Metadata: state-changing, non-idempotent
 | `file_path` | string | Yes | Local path to dataset archive file. |
 | `targetSplit` | string | No |  |
 
-Notes: Uses a local archive file path and starts ingest into an existing dataset.
+Notes: Uses a local archive file path and starts ingest into an existing dataset. Named YOLO ZIP archives preserve labels and classes on later ingests; archives without class names may map labels by positional index.
 
 #### Upload dataset archive
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "fflate": "^0.8.3",
+        "yaml": "^2.9.0",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -2614,6 +2615,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "fflate": "^0.8.3",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/tools/datasets.ts
+++ b/src/tools/datasets.ts
@@ -6,7 +6,8 @@ import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
 import { promisify } from "node:util";
 
-import { zipSync } from "fflate";
+import { strFromU8, unzipSync, zipSync } from "fflate";
+import { parse } from "yaml";
 
 import type { UltralyticsClient } from "../client.js";
 import { resolveDataset } from "../resolve.js";
@@ -256,6 +257,66 @@ async function buildDatasetFolderZip(
   return zipBytes;
 }
 
+function extractArchiveClassMapping(
+  content: Uint8Array,
+  filename: string,
+): Record<string, string> | undefined {
+  if (!filename.toLowerCase().endsWith(".zip")) {
+    return undefined;
+  }
+
+  let files: Record<string, Uint8Array>;
+  try {
+    files = unzipSync(content, {
+      filter: ({ name }) => /(^|\/)data\.ya?ml$/i.test(name),
+    });
+  } catch {
+    return undefined;
+  }
+
+  const paths = Object.keys(files);
+  const rootPaths = paths.filter((path) => !path.includes("/"));
+  const selectedPath =
+    rootPaths.length === 1
+      ? rootPaths[0]
+      : rootPaths.length === 0 && paths.length === 1
+        ? paths[0]
+        : undefined;
+  if (selectedPath === undefined) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parse(strFromU8(files[selectedPath]));
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const names = (parsed as Record<string, unknown>).names;
+  const values = Array.isArray(names)
+    ? names
+    : typeof names === "object" && names !== null
+      ? Object.values(names)
+      : [];
+  if (
+    values.length === 0 ||
+    values.some(
+      (value) => typeof value !== "string" || value.trim().length === 0,
+    )
+  ) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    Array.from(new Set(values.map((value) => (value as string).trim()))).map(
+      (name) => [name, name],
+    ),
+  );
+}
+
 async function uploadDatasetContent(
   client: UltralyticsClient,
   options: {
@@ -265,6 +326,7 @@ async function uploadDatasetContent(
     totalBytes: number;
     content: Uint8Array;
     targetSplit?: string;
+    classMapping?: Record<string, string>;
   },
 ): Promise<{ sessionId: string; ingest: Record<string, unknown> }> {
   const signed = asRecord(
@@ -287,6 +349,12 @@ async function uploadDatasetContent(
   };
   if (options.targetSplit !== undefined) {
     ingestPayload.targetSplit = options.targetSplit;
+  }
+  if (
+    options.classMapping !== undefined &&
+    Object.keys(options.classMapping).length > 0
+  ) {
+    ingestPayload.classMapping = options.classMapping;
   }
   const ingest = asRecord(
     await client.postJson("/datasets/ingest", ingestPayload),
@@ -572,6 +640,7 @@ export async function datasetUploadFile(
   const meta = await datasetUploadFileMeta(options.filePath);
   const datasetId = await resolveDataset(client, options.dataset);
   const content = await readFile(options.filePath);
+  const classMapping = extractArchiveClassMapping(content, meta.filename);
 
   const upload = await uploadDatasetContent(client, {
     datasetId,
@@ -580,6 +649,7 @@ export async function datasetUploadFile(
     totalBytes: meta.totalBytes,
     content,
     targetSplit: options.targetSplit,
+    classMapping,
   });
   const ingest = upload.ingest;
   const jobId = ingest.jobId ?? ingest.id ?? "None";

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -457,7 +457,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
       idempotentHint: false,
     },
     docNote:
-      "Uses a local archive file path and starts ingest into an existing dataset.",
+      "Uses a local archive file path and starts ingest into an existing dataset. Named YOLO ZIP archives preserve labels and classes on later ingests; archives without class names may map labels by positional index.",
     examples: [
       {
         title: "Upload dataset archive",

--- a/tests/tools/datasets.test.ts
+++ b/tests/tools/datasets.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { strToU8, unzipSync, zipSync } from "fflate";
 import { describe, expect, test } from "vitest";
 
 import { UltralyticsClient } from "../../src/client.js";
@@ -41,6 +42,7 @@ function captureClient(responder: (url: string) => Response) {
       fetchImpl: impl,
     }),
     calls,
+    fetchImpl: impl,
   };
 }
 
@@ -810,7 +812,112 @@ describe("datasetsIngest", () => {
 });
 
 describe("datasetUploadFile", () => {
-  test("uploads file through signed URL flow and starts ingest", async () => {
+  test("sends complete identity class mapping from indexed YOLO names", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "ul-mcp-upload-"));
+    const filePath = join(tmp, "coco8.zip");
+    await writeFile(
+      filePath,
+      zipSync({
+        "data.yaml": strToU8("names:\n  0: person\n  1: bicycle\n"),
+      }),
+    );
+
+    const { calls, fetchImpl } = captureClient((url) => {
+      const path = new URL(url).pathname;
+      if (path === "/api/datasets") {
+        return jsonResponse({
+          datasets: [{ _id: "d".repeat(24), slug: "data", username: "user" }],
+        });
+      }
+      if (path === "/api/upload/signed-url") {
+        return jsonResponse({
+          sessionId: "session_123",
+          uploadUrl: "https://signed.example/upload",
+        });
+      }
+      return jsonResponse({ jobId: "job_123" });
+    });
+    const uploadClient = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl,
+      uploadFetchImpl: (async () =>
+        new Response("", { status: 200 })) as unknown as typeof fetch,
+    });
+
+    await datasetUploadFile(uploadClient, {
+      dataset: "user/data",
+      filePath,
+    });
+
+    expect(calls.at(-1)).toMatchObject({
+      body: {
+        classMapping: { person: "person", bicycle: "bicycle" },
+      },
+    });
+  });
+
+  test("sends complete identity class mapping from named YOLO ZIP", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "ul-mcp-upload-"));
+    const filePath = join(tmp, "dataset.ZIP");
+    const archive = zipSync({
+      "data.yaml": strToU8("names:\n  - person\n  - car\n"),
+      "images/large-dummy.jpg": new Uint8Array(1024 * 1024),
+    });
+    await writeFile(filePath, archive);
+
+    expect(
+      Object.keys(
+        unzipSync(archive, {
+          filter: ({ name }) => /(^|\/)data\.ya?ml$/i.test(name),
+        }),
+      ),
+    ).toEqual(["data.yaml"]);
+
+    const calls: { url: string; method: string; body: unknown }[] = [];
+    const client = new UltralyticsClient({
+      apiKey: KEY,
+      baseUrl: BASE,
+      fetchImpl: (async (url: string | URL, init: RequestInit = {}) => {
+        const body =
+          typeof init.body === "string" ? JSON.parse(init.body) : undefined;
+        calls.push({
+          url: String(url),
+          method: (init.method ?? "GET").toUpperCase(),
+          body,
+        });
+        const path = new URL(String(url)).pathname;
+        if (path === "/api/datasets") {
+          return jsonResponse({
+            datasets: [{ _id: "d".repeat(24), slug: "data", username: "user" }],
+          });
+        }
+        if (path === "/api/upload/signed-url") {
+          return jsonResponse({
+            sessionId: "session_123",
+            uploadUrl: "https://signed.example/upload",
+          });
+        }
+        return jsonResponse({ jobId: "job_123" });
+      }) as unknown as typeof fetch,
+      uploadFetchImpl: (async () =>
+        new Response("", { status: 200 })) as unknown as typeof fetch,
+    });
+
+    await datasetUploadFile(client, { dataset: "user/data", filePath });
+
+    expect(calls.at(-1)).toEqual({
+      url: `${BASE}/datasets/ingest`,
+      method: "POST",
+      body: {
+        datasetId: "d".repeat(24),
+        sessionId: "session_123",
+        classMapping: { person: "person", car: "car" },
+      },
+    });
+  });
+
+  test("omits class mapping for an archive with no readable YAML metadata", async () => {
     const tmp = await mkdtemp(join(tmpdir(), "ul-mcp-upload-"));
     const filePath = join(tmp, "dataset.zip");
     await writeFile(filePath, "archive");


### PR DESCRIPTION
## Summary
- Preserve named YOLO archive labels and classes on later dataset ingests.

## Motivation
- Platform needs classMapping to reconcile named archive labels.

## Key Changes
- Derive filtered ZIP class mappings, add regression coverage, document behavior.