### PR TITLE
docs: refresh dataset upload limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ See [TOOLS.md](./TOOLS.md) for full parameter reference, safety notes, local-pat
 - Signed upload and download URLs do not forward `Authorization`
 - Local upload tools read files from the MCP client host; approve calls only for paths you expect to share with Ultralytics
 - `model_download` writes to the requested local path; review `output_path` and `overwrite` before approving
-- Re-uploading labeled copies may duplicate dataset image records instead of attaching labels to existing images
-- Images-only dataset uploads may be inferred as `classify`; include labels when task preservation matters
+- Adding a named YOLO ZIP (with `data.yaml` class names) to an existing dataset imports its labels and merges classes
+- Re-ingest does not re-label images already in the dataset (use the annotation editor); re-uploading the same image under a different split can create a duplicate
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Refresh dataset-upload limitations after shipped label and task fixes.

## Motivation
- portal#2905 resolved task override. Named YOLO ZIP re-ingests preserve labels.

## Key Changes
- Remove obsolete task override limitation and document re-ingest behavior.

Closes #54